### PR TITLE
feat: 채팅 사이드바 상태관리 및 상품 상세 이동 기능 개선

### DIFF
--- a/src/app/chat/components/ChatListSideBar.jsx
+++ b/src/app/chat/components/ChatListSideBar.jsx
@@ -44,7 +44,9 @@ export default function ChatListSidebar({ trigger }) {
   };
 
   return (
+    // ChatListSidebar.jsx
     <Sidebar
+      sidebarKey="chatList"
       title="채팅 목록"
       trigger={
         <button className="flex items-center gap-1 cursor-pointer">
@@ -53,20 +55,13 @@ export default function ChatListSidebar({ trigger }) {
         </button>
       }
     >
-      <div className="space-y-4">
-        <ul className="[&>li]:border-b">
-          {chatRoomData.map((chat) => (
-            <li key={chat.id}>
-              <ChatRoomSidebar
-                chat={{
-                  ...chat,
-                  ...productMap[chat.productId], // productId로 상품 정보 매핑
-                }}
-              />
-            </li>
-          ))}
-        </ul>
-      </div>
+      <ul className="[&>li]:border-b">
+        {chatRoomData.map((chat) => (
+          <li key={chat.id}>
+            <ChatRoomSidebar chat={{ ...chat, ...productMap[chat.productId] }} />
+          </li>
+        ))}
+      </ul>
     </Sidebar>
   );
 }

--- a/src/app/chat/components/ChatRoomSidebar.jsx
+++ b/src/app/chat/components/ChatRoomSidebar.jsx
@@ -1,4 +1,3 @@
-// components/chat/ChatRoomSidebar.jsx
 "use client";
 
 import Sidebar from "@/components/common/Sidebar";
@@ -7,8 +6,11 @@ import { useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { formatDateToString, formatStringToDate, numberWithCommas } from "@/utils/format";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useSidebar } from "@/hooks/useSidebar";
 
 export default function ChatRoomSidebar({ chat }) {
+  const { close, closeAll } = useSidebar(`chatRoom_${chat.id}`);
   const [text, setText] = useState("");
   const [messages, setMessages] = useState([
     {
@@ -21,7 +23,9 @@ export default function ChatRoomSidebar({ chat }) {
   const scrollRef = useRef(null);
   const myId = "나";
 
-  // 메시지 전송 처리
+  const router = useRouter();
+
+  // 메시지 전송
   const handleSend = (e) => {
     e.preventDefault();
     if (!text.trim()) return;
@@ -34,13 +38,12 @@ export default function ChatRoomSidebar({ chat }) {
     setMessages((prev) => [...prev, newMessage]);
     setText("");
 
-    // 메시지 전송 후 스크롤 하단으로 이동
     setTimeout(() => {
       scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
     }, 0);
   };
 
-  // Enter 키로 메시지 전송 처리
+  // 엔터키 전송
   const handleKeyDown = (e) => {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
@@ -48,13 +51,11 @@ export default function ChatRoomSidebar({ chat }) {
     }
   };
 
-  // 시간 포맷 함수 (오전/오후 시:분)
+  // 날짜 포맷
   const formatTime = (iso) => {
     const date = new Date(iso);
     return date.toLocaleTimeString("ko-KR", { hour: "2-digit", minute: "2-digit" });
   };
-
-  // 날짜 포맷 함수 (YYYY년 MM월 DD일)
   const formatFullDate = (timestamp) => {
     const date = new Date(timestamp);
     if (isNaN(date.getTime())) return "";
@@ -62,11 +63,20 @@ export default function ChatRoomSidebar({ chat }) {
     return formatStringToDate(dateString);
   };
 
+  // 상품 클릭 시 사이드바 전부 닫고 이동
+  const handleGoToReview = () => {
+    closeAll();
+    // 상품 상세페이지로 이동
+    // router.push(`/product/${chat.productId}`);
+    // 테스트용
+    router.push("/review");
+  };
+
   return (
     <Sidebar
-      title={`${chat.name}`}
+      sidebarKey={`chatRoom_${chat.id}`}
+      title={chat.name}
       trigger={
-        // 채팅방 목록에 출력되는 미리보기 버튼
         <Button variant="ghost" className="flex items-center gap-4 w-full h-[86px]">
           <div className="w-[60px] h-[60px] bg-gray-200 rounded-full flex items-center justify-center">
             {chat.avatar ? (
@@ -89,34 +99,25 @@ export default function ChatRoomSidebar({ chat }) {
           )}
         </Button>
       }
-      onBack={true}
+      onBack={() => {
+        close(); // 현재 닫고
+        useSidebar("chatList").open(); // chatList 열기
+      }}
     >
       <div>
-        {/* 채팅방 상단 상품 정보 */}
-        {chat && (
-          <div className="rounded-lg flex justify-between">
-            {/* 상품 정보 링크 영역 */}
-            <Link href="#" className="flex items-center gap-4 w-full h-[40px] mb-3 ">
-              {/* 상품 이미지 */}
-              <Image src={chat.productImg} alt="product" width={40} height={40} className="rounded" />
-
-              {/* 상품명 + 가격 */}
-              <div className="flex-1 min-w-0">
-                <div className="flex flex-col items-start text-sm">
-                  <span className="font-medium text-base text-gray-900 truncate">{chat.productName}</span>
-                  <span className="text-xs text-gray-500">{numberWithCommas(chat.productPrice)}원</span>
-                </div>
-              </div>
-            </Link>
-            {/* 판매 완료 버튼 (isSale === true일 때 비활성화) */}
-            <Button disabled={chat.isSale} onClick={() => console.log("클릭됨")}>
-              판매완료
-            </Button>
+        {/* 상품 정보 클릭 시 이동 */}
+        <div onClick={handleGoToReview} className="flex items-center gap-4 w-full h-[40px] mb-3 cursor-pointer">
+          <Image src={chat.productImg} alt="product" width={40} height={40} className="rounded" />
+          <div className="flex-1 min-w-0">
+            <div className="flex flex-col items-start text-sm">
+              <span className="font-medium text-base text-gray-900 truncate">{chat.productName}</span>
+              <span className="text-xs text-gray-500">{numberWithCommas(chat.productPrice)}원</span>
+            </div>
           </div>
-        )}
+        </div>
 
+        {/* 메시지 목록 */}
         <div className="flex flex-col gap-2">
-          {/* 메시지 목록 */}
           <div ref={scrollRef} className="overflow-auto p-5 h-[470px] bg-gray-200">
             {messages.map((msg, idx) => {
               const isMine = msg.from === myId;
@@ -127,30 +128,21 @@ export default function ChatRoomSidebar({ chat }) {
 
               return (
                 <div key={idx}>
-                  {/* 날짜 표시 */}
                   {showDate && (
                     <div className="text-center text-xs text-gray-500 my-2">{formatFullDate(msg.timestamp)}</div>
                   )}
 
-                  {/* 메시지 박스 - 나 / 상대방 구분 */}
                   <div className={`mb-2 flex ${isMine ? "justify-end" : "justify-start"}`}>
                     <div className={`${isMine ? "text-right" : "text-left"}`}>
-                      {/* 보낸 사람 이름 (상대방만 표시) */}
                       {!isMine && <div className="text-sm text-gray-500 mb-1">{msg.from}</div>}
-
-                      {/* 메시지 + 시간 묶음 */}
                       <div className={`flex items-end gap-2 ${isMine ? "flex-row-reverse" : "flex-row"}`}>
                         <div
                           className={`p-3 rounded break-all max-w-[250px] ${isMine ? "bg-blue-300" : "bg-green-300"}`}
                         >
                           {msg.text}
                         </div>
-                        <span className="text-[11px] text-gray-600 mb-0.5 whitespace-nowrap">
-                          {formatTime(msg.timestamp)}
-                        </span>
+                        <span className="text-[11px] text-gray-600 whitespace-nowrap">{formatTime(msg.timestamp)}</span>
                       </div>
-
-                      {/* 읽음 여부 (내 메시지일 때만 표시) */}
                       {isMine && <div className="text-xs text-gray-600 mt-0.5">{msg.read ? "읽음 ✅" : "전송됨"}</div>}
                     </div>
                   </div>
@@ -159,7 +151,7 @@ export default function ChatRoomSidebar({ chat }) {
             })}
           </div>
 
-          {/* 메시지 입력창 */}
+          {/* 입력창 */}
           <form onSubmit={handleSend} className="flex flex-col gap-1">
             <textarea
               value={text}

--- a/src/app/store/sidebarStore.js
+++ b/src/app/store/sidebarStore.js
@@ -1,8 +1,0 @@
-import { create } from "zustand";
-
-export const useSidebarStore = create((set) => ({
-  isOpen: false,
-  open: () => set({ isOpen: true }),
-  close: () => set({ isOpen: false }),
-  toggle: () => set((state) => ({ isOpen: !state.isOpen })),
-}));

--- a/src/components/common/Sidebar.jsx
+++ b/src/components/common/Sidebar.jsx
@@ -2,9 +2,10 @@
 
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetClose } from "@/components/ui/sheet";
 import { ChevronLeft, X } from "lucide-react";
-import { useState } from "react";
+import { useSidebar } from "@/hooks/useSidebar";
 
 export default function Sidebar({
+  sidebarKey,
   title,
   trigger,
   children,
@@ -16,48 +17,51 @@ export default function Sidebar({
   onBack = false,
   onClose = false,
 }) {
-  const [open, setOpen] = useState(false);
+  const { isOpen, open, close } = useSidebar(sidebarKey);
 
   return (
-    <Sheet open={open} onOpenChange={setOpen}>
-      <div onClick={() => setOpen(true)}>{trigger}</div>
+    <>
+      <div onClick={open}>{trigger}</div>
 
-      <SheetContent side="right" className={`${className} max-w-[600px]`}>
-        <SheetHeader className="pt-4 border-b">
-          <div className="flex items-center justify-between relative">
-            {/* 뒤로가기 버튼 */}
-            {onBack ? (
-              <button
-                onClick={() => setOpen(false)}
-                className="p-1 hover:bg-gray-100 rounded-full transition-colors"
-                aria-label="뒤로가기"
-              >
-                <ChevronLeft />
-              </button>
-            ) : (
-              <div className="w-6 h-6" />
-            )}
+      <Sheet
+        open={isOpen}
+        onOpenChange={(val) => {
+          if (val) {
+            closeAll(); // 모든 사이드바 닫고
+            open(); // 이 사이드바만 열기
+          } else {
+            close();
+          }
+        }}
+      >
+        <SheetContent side="right" className={`${className} max-w-[600px]`}>
+          <SheetHeader className="pt-4 border-b">
+            <div className="flex items-center justify-between relative">
+              {onBack ? (
+                <button onClick={close} className="p-1 hover:bg-gray-100 rounded-full" aria-label="뒤로가기">
+                  <ChevronLeft />
+                </button>
+              ) : (
+                <div className="w-6 h-6" />
+              )}
+              <SheetTitle className={titleClassName} style={titleStyle} {...titleProps}>
+                {title}
+              </SheetTitle>
+              {onClose ? (
+                <SheetClose className="pr-5 hover:bg-gray-100 rounded-full" aria-label="닫기">
+                  <X className="w-6 h-6" />
+                </SheetClose>
+              ) : (
+                <div className="w-6 h-6" />
+              )}
+            </div>
+          </SheetHeader>
 
-            {/* 중앙 타이틀 */}
-            <SheetTitle className={titleClassName} style={titleStyle} {...titleProps}>
-              {title}
-            </SheetTitle>
+          <div className="flex-1 overflow-y-auto px-5">{children}</div>
 
-            {/* 닫기 버튼 */}
-            {onClose ? (
-              <SheetClose className="pr-5 hover:bg-gray-100 rounded-full transition-colors" aria-label="닫기">
-                <X className="w-6 h-6" />
-              </SheetClose>
-            ) : (
-              <div className="w-6 h-6" />
-            )}
-          </div>
-        </SheetHeader>
-
-        <div className="flex-1 overflow-y-auto px-5">{children}</div>
-
-        {footer && <div className="border-t pt-4 mt-4">{footer}</div>}
-      </SheetContent>
-    </Sheet>
+          {footer && <div className="border-t pt-4 mt-4">{footer}</div>}
+        </SheetContent>
+      </Sheet>
+    </>
   );
 }

--- a/src/hooks/useSidebar.js
+++ b/src/hooks/useSidebar.js
@@ -1,0 +1,12 @@
+import { useSidebarStore } from "@/store/sidebarStore";
+
+export const useSidebar = (key) => {
+  const isOpen = useSidebarStore((state) => state.sidebars[key]);
+
+  const open = () => useSidebarStore.getState().open(key);
+  const close = () => useSidebarStore.getState().close(key);
+  const toggle = () => useSidebarStore.getState().toggle(key);
+  const closeAll = () => useSidebarStore.getState().closeAll();
+
+  return { isOpen, open, close, toggle, closeAll };
+};

--- a/src/store/sidebarStore.js
+++ b/src/store/sidebarStore.js
@@ -1,0 +1,30 @@
+// store/sidebarStore.js
+import { create } from "zustand";
+
+export const useSidebarStore = create((set) => ({
+  sidebars: {},
+  open: (key) =>
+    set((state) => ({
+      sidebars: { ...state.sidebars, [key]: true },
+    })),
+  close: (key) =>
+    set((state) => ({
+      sidebars: { ...state.sidebars, [key]: false },
+    })),
+
+  closeAll: () =>
+    set((state) => ({
+      sidebars: Object.keys(state.sidebars).reduce((acc, key) => {
+        acc[key] = false;
+        return acc;
+      }, {}),
+    })),
+  toggle: (key) =>
+    set((state) => ({
+      sidebars: {
+        ...state.sidebars,
+        [key]: !state.sidebars[key],
+      },
+    })),
+  isOpen: (key) => (state) => !!state.sidebars[key],
+}));


### PR DESCRIPTION
- useSidebar 훅을 도입하여 상태 관리 방식 개선 (open, close, closeAll 포함)
- ChatRoomSidebar 컴포넌트에 개별 사이드바 상태 연결 (chatRoom_{id})
- 중첩 사이드바 구조에서 chatList ↔ chatRoom 간 상태 전환 구현
- 상품 클릭 시 closeAll() 후 router.push로 상세 페이지 이동 처리
- useSidebar는 컴포넌트 최상단에서 선언해 React hook 규칙 준수