### PR TITLE
feat: 아이디/비밀번호 찾기 기능 구현

### DIFF
--- a/src/app/(user)/components/emailUtils.js
+++ b/src/app/(user)/components/emailUtils.js
@@ -1,0 +1,36 @@
+export const validateEmail = (email) => {
+    if (!email.trim()) {
+        return { isValid: false, message: '이메일을 입력해주세요' };
+    }
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+        return { isValid: false, message: '올바른 이메일 형식을 입력해주세요' };
+    }
+
+    return { isValid: true, message: '' };
+};
+
+export const validateName = (name) => {
+    if (!name.trim()) {
+        return { isValid: false, message: '이름을 입력해주세요' };
+    }
+
+    if (name.length < 2) {
+        return { isValid: false, message: '이름은 2글자 이상 입력해주세요' };
+    }
+
+    return { isValid: true, message: '' };
+};
+
+export const validateLoginId = (loginId) => {
+    if (!loginId.trim()) {
+        return { isValid: false, message: '아이디를 입력해주세요' };
+    }
+
+    if (loginId.length < 4) {
+        return { isValid: false, message: '아이디는 4글자 이상 입력해주세요' };
+    }
+
+    return { isValid: true, message: '' };
+};

--- a/src/app/(user)/find-account/find-account.css
+++ b/src/app/(user)/find-account/find-account.css
@@ -1,0 +1,361 @@
+/* Reset and base styles */
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: "Pretendard Variable";
+  background-color: #ffffff;
+}
+
+/* Find Account Container */
+.find-account-container {
+  min-height: 100vh;
+  background: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+
+/* Find Account Card */
+.find-account-card {
+  width: 640px;
+  background: #fff;
+  border-radius: 8px;
+  border: 1px solid #dddddd;
+  padding: 64px 131px;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 10px;
+  position: relative;
+}
+
+/* Find Account Content */
+.find-account-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center; /* 로고만 중앙 정렬되게*/
+  gap: 10px;
+  width: 100%;
+  padding-bottom: 50px;
+}
+
+/* Tab Navigation */
+.tab-navigation {
+  align-self: flex-start; /* 탭 네비게이션만 왼쪽 정렬 */
+  width: 100%;
+  display: flex;
+  align-items: center; /* 세로 중앙 정렬 */
+  justify-content: flex-start;
+  padding: 0; /* 패딩 제거 */
+  margin-bottom: 20px;
+}
+
+.tab-btn {
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 14px;
+  color: #666;
+  height: 40px; /* 높이 지정 */
+  display: flex;
+  align-items: center; /* 텍스트 세로 중앙 정렬 */
+}
+
+.tab-btn.active {
+  color: #000;
+  font-weight: bold;
+}
+
+.tab-btn:hover {
+  color: #000000;
+}
+
+.tab-divider {
+  display: flex;
+  align-items: center;
+  height: 40px; /* 높이를 탭 버튼과 동일하게 */
+  color: #ddd;
+  margin: 0 8px;
+}
+
+/* Logo Container */
+.logo-container {
+  width: 174px;
+  height: 129px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 20px auto; /* auto로 변경하여 가운데 정렬 */
+}
+
+.logo-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+/* Form */
+.find-form {
+  width: 360px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+/* Form Group */
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.form-input {
+  width: 100%;
+  height: 46px;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 0 16px;
+  font-family: "Inter", sans-serif;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 1.21;
+  color: #000000;
+  background-color: #ffffff;
+  outline: none;
+  transition: border-color 0.3s ease;
+}
+
+.form-input::placeholder {
+  color: #94a3b8;
+}
+
+.form-input:focus {
+  border-color: #85b3eb;
+}
+
+.form-input.error {
+  border-color: #ef4444;
+}
+
+/* Input with Button */
+.input-with-button {
+  display: flex;
+  gap: 8px;
+}
+
+.form-input-with-btn {
+  flex: 1;
+  height: 46px;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 0 16px;
+  font-family: "Inter", sans-serif;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 1.21;
+  color: #000000;
+  background-color: #ffffff;
+  outline: none;
+  transition: border-color 0.3s ease;
+}
+
+.form-input-with-btn::placeholder {
+  color: #94a3b8;
+}
+
+.form-input-with-btn:focus {
+  border-color: #85b3eb;
+}
+
+.form-input-with-btn.error {
+  border-color: #ef4444;
+}
+
+.verify-btn {
+  width: 80px;
+  height: 46px;
+  background-color: #85b3eb;
+  border: none;
+  border-radius: 8px;
+  font-family: "Pretendard Variable", sans-serif;
+  font-weight: 500;
+  font-size: 14px;
+  color: #ffffff;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  flex-shrink: 0;
+}
+
+.verify-btn:hover:not(:disabled) {
+  background-color: #6b9aff;
+}
+
+.verify-btn:disabled {
+  background-color: #cbd5e1;
+  color: #94a3b8;
+  cursor: not-allowed;
+}
+
+/* Error and Success Messages */
+.error-message {
+  font-family: "Inter", sans-serif;
+  font-size: 12px;
+  color: #ef4444;
+  margin-top: 4px;
+}
+
+.success-message {
+  font-family: "Inter", sans-serif;
+  font-size: 12px;
+  color: #10b981;
+  margin-top: 4px;
+  font-weight: 500;
+}
+
+/* Info Message */
+.info-message {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  justify-content: center;
+  margin: 10px 0;
+}
+
+.info-icon {
+  width: 24px;
+  height: 24px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.info-text {
+  font-family: "Pretendard Variable", sans-serif;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 1.19;
+  color: #94a3b8;
+}
+
+/* Submit Button */
+.submit-button {
+  width: 100%;
+  height: 48px;
+  border: none;
+  border-radius: 8px;
+  font-family: "Pretendard Variable", sans-serif;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.5;
+  text-align: center;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  margin-top: 20px;
+}
+
+.submit-button.active {
+  background-color: #85b3eb;
+  color: #ffffff;
+}
+
+.submit-button.active:hover {
+  background-color: #6b9aff;
+}
+
+.submit-button.disabled {
+  background-color: rgba(221, 221, 221, 0.87);
+  color: #94a3b8;
+  cursor: not-allowed;
+}
+
+/* ConfirmModal CSS 수정 */
+.dialog-content {
+  min-height: 280px;
+  padding: 48px 32px; /* 상하 여백 증가 */
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center; /* 내용 중앙 정렬 */
+  text-align: center; /* 텍스트 중앙 정렬 */
+  gap: 16px; /* 요소들 사이 간격 추가 */
+}
+
+/* 모달 내부 텍스트 스타일 추가 */
+.result-text {
+  display: flex;
+  align-items: center;
+  gap: 4px; /* 텍스트 사이 간격 */
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.result-id {
+  font-weight: bold;
+  color: #000;
+}
+
+/* 모달 버튼 스타일 수정 */
+.modal-buttons {
+  display: flex;
+  gap: 12px;
+  margin-top: 24px; /* 버튼과 텍스트 사이 여백 */
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+  .find-account-container {
+    padding: 20px 10px;
+  }
+
+  .find-account-card {
+    width: 100%;
+    max-width: 640px;
+    padding: 40px 20px;
+  }
+
+  .find-form {
+    width: 100%;
+    max-width: 360px;
+  }
+
+  .input-with-button {
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .verify-btn {
+    width: 100%;
+  }
+}
+
+@media (max-width: 480px) {
+  .find-account-card {
+    padding: 30px 16px;
+  }
+
+  .logo-container {
+    width: 120px;
+    height: 90px;
+  }
+
+  .tab-btn {
+    font-size: 14px;
+  }
+
+  .form-input,
+  .form-input-with-btn,
+  .verify-btn {
+    height: 40px;
+    font-size: 12px;
+  }
+
+  .submit-button {
+    height: 44px;
+    font-size: 14px;
+  }
+}

--- a/src/app/(user)/find-account/page.jsx
+++ b/src/app/(user)/find-account/page.jsx
@@ -1,0 +1,457 @@
+"use client";
+
+import React, { useState, useEffect } from 'react';
+import Link from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
+import ConfirmModal, { MODAL_TYPES } from '@/components/common/ConfirmModal';
+import { validatePassword } from '@/app/(user)/components/passwordUtils';
+import { createValidationSetter } from '@/app/(user)/components/duplicateUtils';
+import { validateEmail, validateName, validateLoginId } from '@/app/(user)/components/emailUtils';
+import './find-account.css';
+
+const FindAccount = () => {
+    const router = useRouter();
+    const searchParams = useSearchParams();
+    
+    // URL 파라미터에서 탭 결정 (기본값: findId)
+    const getInitialTab = () => {
+        const tab = searchParams.get('tab');
+        return tab === 'password' ? 'findPassword' : 'findId';
+    };
+
+    const [activeTab, setActiveTab] = useState(getInitialTab());
+    const [formData, setFormData] = useState({
+        name: '',
+        email: '',
+        loginId: '',
+        passwordEmail: '',
+        newPassword: '',
+        newPasswordConfirm: ''
+    });
+
+    const [validationStates, setValidationStates] = useState({
+        name: { status: 'default', message: '', checked: false },
+        email: { status: 'default', message: '', checked: false },
+        loginId: { status: 'default', message: '', checked: false },
+        passwordEmail: { status: 'default', message: '', checked: false }
+    });
+
+    const [isLoading, setIsLoading] = useState(false);
+    const [passwordValidation, setPasswordValidation] = useState({ status: 'default', message: '' });
+    const [resultModal, setResultModal] = useState({
+        isOpen: false,
+        type: '',
+        data: null
+    });
+
+    const setValidationMessage = createValidationSetter(setValidationStates);
+
+    // URL 파라미터 변경 시 탭 업데이트
+    useEffect(() => {
+        const tab = searchParams.get('tab');
+        if (tab === 'password') {
+            setActiveTab('findPassword');
+        } else {
+            setActiveTab('findId');
+        }
+    }, [searchParams]);
+
+    const checkAccountExists = async (type, data) => {
+        return new Promise(resolve => {
+            setTimeout(() => {
+                try {
+                    const registeredUsers = JSON.parse(localStorage.getItem('registeredUsers') || '[]');
+                    const testAccounts = [
+                        { name: '홍길동', email: 'hong@example.com', loginId: 'hongildong' },
+                        { name: '김철수', email: 'kim@example.com', loginId: 'kimchulsoo' },
+                        { name: '이영희', email: 'lee@example.com', loginId: 'leeyounghee' }
+                    ];
+
+                    const allAccounts = [...registeredUsers, ...testAccounts];
+
+                    if (type === 'findId') {
+                        const account = allAccounts.find(acc =>
+                            acc.name === data.name && acc.email === data.email
+                        );
+                        resolve({
+                            success: !!account,
+                            data: account ? { loginId: account.loginId } : null,
+                            message: account ? '계정이 확인되었습니다' : '일치하는 계정을 찾을 수 없습니다'
+                        });
+                    } else {
+                        const account = allAccounts.find(acc =>
+                            acc.loginId === data.loginId && acc.email === data.passwordEmail
+                        );
+                        resolve({
+                            success: !!account,
+                            data: account ? { email: account.email } : null,
+                            message: account ? '계정이 확인되었습니다' : '일치하는 계정을 찾을 수 없습니다'
+                        });
+                    }
+                } catch (error) {
+                    resolve({
+                        success: false,
+                        data: null,
+                        message: '계정 확인 중 오류가 발생했습니다'
+                    });
+                }
+            }, 1500);
+        });
+    };
+
+    const handleInputChange = (e) => {
+        const { name, value } = e.target;
+        setFormData(prev => ({ ...prev, [name]: value }));
+
+        // 실시간 검증
+        let validation = { isValid: true, message: '' };
+
+        if (name === 'name') {
+            validation = validateName(value);
+            setValidationMessage('name', validation.isValid ? 'default' : 'error', validation.message);
+        } else if (name === 'email') {
+            validation = validateEmail(value);
+            setValidationMessage('email', validation.isValid ? 'default' : 'error', validation.message);
+            if (validationStates.email.checked) {
+                setValidationMessage('email', 'default', '', false);
+            }
+        } else if (name === 'loginId') {
+            validation = validateLoginId(value);
+            setValidationMessage('loginId', validation.isValid ? 'default' : 'error', validation.message);
+        } else if (name === 'passwordEmail') {
+            validation = validateEmail(value);
+            setValidationMessage('passwordEmail', validation.isValid ? 'default' : 'error', validation.message);
+            if (validationStates.passwordEmail.checked) {
+                setValidationMessage('passwordEmail', 'default', '', false);
+            }
+        }
+
+        // 비밀번호 검증
+        if (name === 'newPassword' || name === 'newPasswordConfirm') {
+            const password = name === 'newPassword' ? value : formData.newPassword;
+            const passwordConfirm = name === 'newPasswordConfirm' ? value : formData.newPasswordConfirm;
+            const result = validatePassword(password, passwordConfirm);
+            setPasswordValidation(result);
+        }
+    };
+
+    const handleTabChange = (tab) => {
+        setActiveTab(tab);
+        
+        // URL 파라미터 업데이트
+        const newTab = tab === 'findPassword' ? 'password' : 'id';
+        router.replace(`/find-account?tab=${newTab}`, { scroll: false });
+        
+        setValidationStates({
+            name: { status: 'default', message: '', checked: false },
+            email: { status: 'default', message: '', checked: false },
+            loginId: { status: 'default', message: '', checked: false },
+            passwordEmail: { status: 'default', message: '', checked: false }
+        });
+        setPasswordValidation({ status: 'default', message: '' });
+        setResultModal({ isOpen: false, type: '', data: null });
+        setFormData({
+            name: '', email: '', loginId: '', passwordEmail: '', newPassword: '', newPasswordConfirm: ''
+        });
+    };
+
+    const handleVerify = async () => {
+        // 폼 검증
+        let hasError = false;
+
+        if (activeTab === 'findId') {
+            const nameValidation = validateName(formData.name);
+            const emailValidation = validateEmail(formData.email);
+
+            if (!nameValidation.isValid) {
+                setValidationMessage('name', 'error', nameValidation.message);
+                hasError = true;
+            }
+            if (!emailValidation.isValid) {
+                setValidationMessage('email', 'error', emailValidation.message);
+                hasError = true;
+            }
+        } else {
+            const loginIdValidation = validateLoginId(formData.loginId);
+            const emailValidation = validateEmail(formData.passwordEmail);
+
+            if (!loginIdValidation.isValid) {
+                setValidationMessage('loginId', 'error', loginIdValidation.message);
+                hasError = true;
+            }
+            if (!emailValidation.isValid) {
+                setValidationMessage('passwordEmail', 'error', emailValidation.message);
+                hasError = true;
+            }
+        }
+
+        if (hasError) return;
+
+        setIsLoading(true);
+        const field = activeTab === 'findId' ? 'email' : 'passwordEmail';
+        setValidationMessage(field, 'loading', '🔄 확인 중...');
+
+        try {
+            const data = activeTab === 'findId'
+                ? { name: formData.name, email: formData.email }
+                : { loginId: formData.loginId, passwordEmail: formData.passwordEmail };
+
+            const result = await checkAccountExists(activeTab, data);
+
+            if (result.success) {
+                setValidationMessage(field, 'success', '✅ 계정이 확인되었습니다', true);
+            } else {
+                setValidationMessage(field, 'error', `❌ ${result.message}`);
+            }
+        } catch (error) {
+            setValidationMessage(field, 'error', '❌ 확인 중 오류가 발생했습니다');
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+
+        const field = activeTab === 'findId' ? 'email' : 'passwordEmail';
+        if (!validationStates[field].checked) return;
+
+        if (activeTab === 'findId') {
+            const data = { name: formData.name, email: formData.email };
+            const result = await checkAccountExists(activeTab, data);
+
+            if (result.success) {
+                setResultModal({
+                    isOpen: true,
+                    type: 'idResult',
+                    data: result.data
+                });
+            }
+        } else {
+            if (passwordValidation.status !== 'success') return;
+
+            setResultModal({
+                isOpen: true,
+                type: 'passwordResult',
+                data: null
+            });
+        }
+    };
+
+    const closeModal = () => {
+        setResultModal({ isOpen: false, type: '', data: null });
+    };
+
+    const handleLoginRedirect = () => {
+        closeModal();
+        router.push('/login');
+    };
+
+    const handlePasswordFindRedirect = () => {
+        closeModal();
+        setActiveTab('findPassword');
+        router.replace('/find-account?tab=password', { scroll: false });
+    };
+
+    // 버튼 활성화 조건
+    const isIdFindEnabled = validationStates.email.checked;
+    const isPasswordResetEnabled = validationStates.passwordEmail.checked &&
+        formData.newPassword && formData.newPasswordConfirm &&
+        passwordValidation.status === 'success';
+
+    const renderFindIdForm = () => (
+        <>
+            <div className="form-group">
+                <input
+                    type="text"
+                    name="name"
+                    value={formData.name}
+                    onChange={handleInputChange}
+                    autoComplete="off"
+                    className={`form-input ${validationStates.name.status === 'error' ? 'error' : ''}`}
+                    placeholder="이름을 입력해 주세요"
+                />
+                {validationStates.name.message && (
+                    <span className="error-message">{validationStates.name.message}</span>
+                )}
+            </div>
+
+            <div className="form-group">
+                <div className="input-with-button">
+                    <input
+                        type="email"
+                        name="email"
+                        value={formData.email}
+                        onChange={handleInputChange}
+                        autoComplete="off"
+                        className={`form-input-with-btn ${validationStates.email.status === 'error' ? 'error' : ''}`}
+                        placeholder="이메일을 입력해 주세요"
+                    />
+                    <button
+                        type="button"
+                        className="verify-btn"
+                        onClick={handleVerify}
+                        disabled={isLoading || validationStates.email.checked}
+                    >
+                        {isLoading ? '확인중...' : validationStates.email.checked ? '✓ 확인됨' : '확인'}
+                    </button>
+                </div>
+                {validationStates.email.message && (
+                    <span className={`${validationStates.email.status === 'success' ? 'success-message' : 'error-message'}`}>
+                        {validationStates.email.message}
+                    </span>
+                )}
+            </div>
+        </>
+    );
+
+    const renderFindPasswordForm = () => (
+        <>
+            <div className="form-group">
+                <input
+                    type="text"
+                    name="loginId"
+                    value={formData.loginId}
+                    onChange={handleInputChange}
+                    autoComplete="off"
+                    className={`form-input ${validationStates.loginId.status === 'error' ? 'error' : ''}`}
+                    placeholder="아이디를 입력해 주세요"
+                />
+                {validationStates.loginId.message && (
+                    <span className="error-message">{validationStates.loginId.message}</span>
+                )}
+            </div>
+
+            <div className="form-group">
+                <div className="input-with-button">
+                    <input
+                        type="email"
+                        name="passwordEmail"
+                        value={formData.passwordEmail}
+                        onChange={handleInputChange}
+                        autoComplete="off"
+                        className={`form-input-with-btn ${validationStates.passwordEmail.status === 'error' ? 'error' : ''}`}
+                        placeholder="이메일을 입력해 주세요"
+                    />
+                    <button
+                        type="button"
+                        className="verify-btn"
+                        onClick={handleVerify}
+                        disabled={isLoading || validationStates.passwordEmail.checked}
+                    >
+                        {isLoading ? '확인중...' : validationStates.passwordEmail.checked ? '✓ 확인됨' : '확인'}
+                    </button>
+                </div>
+                {validationStates.passwordEmail.message && (
+                    <span className={`${validationStates.passwordEmail.status === 'success' ? 'success-message' : 'error-message'}`}>
+                        {validationStates.passwordEmail.message}
+                    </span>
+                )}
+            </div>
+
+            {validationStates.passwordEmail.checked && (
+                <>
+                    <div className="form-group">
+                        <input
+                            type="password"
+                            name="newPassword"
+                            value={formData.newPassword}
+                            onChange={handleInputChange}
+                            autoComplete="new-password"
+                            className={`form-input ${passwordValidation.status === 'error' ? 'error' : ''}`}
+                            placeholder="새 비밀번호를 입력하세요"
+                        />
+                    </div>
+
+                    <div className="form-group">
+                        <input
+                            type="password"
+                            name="newPasswordConfirm"
+                            value={formData.newPasswordConfirm}
+                            onChange={handleInputChange}
+                            autoComplete="new-password"
+                            className={`form-input ${passwordValidation.status === 'error' ? 'error' : ''}`}
+                            placeholder="새 비밀번호를 확인하세요"
+                        />
+                        {passwordValidation.message && (
+                            <span className={`${passwordValidation.status === 'success' ? 'success-message' : 'error-message'}`}>
+                                {passwordValidation.message}
+                            </span>
+                        )}
+                    </div>
+                </>
+            )}
+        </>
+    );
+
+    return (
+        <div className="find-account-container">
+            <div className="find-account-card">
+                <div className="find-account-content">
+
+                    <div className="logo-container">
+                        <Link href="/">
+                            <img src="/images/common/main-logo.png" alt="Logo" className="logo-image" />
+                        </Link>
+                    </div>
+
+                    <div className="tab-navigation">
+                        <button
+                            className={`tab-btn ${activeTab === 'findId' ? 'active' : ''}`}
+                            onClick={() => handleTabChange('findId')}
+                        >
+                            아이디 찾기
+                        </button>
+                        <span className="tab-divider">|</span>
+                        <button
+                            className={`tab-btn ${activeTab === 'findPassword' ? 'active' : ''}`}
+                            onClick={() => handleTabChange('findPassword')}
+                        >
+                            비밀번호 찾기
+                        </button>
+                    </div>
+
+                    <div className="find-form">
+                        {activeTab === 'findId' ? renderFindIdForm() : renderFindPasswordForm()}
+
+                        <button
+                            onClick={handleSubmit}
+                            className={`submit-button ${
+                                (activeTab === 'findId' && isIdFindEnabled) ||
+                                (activeTab === 'findPassword' && isPasswordResetEnabled)
+                                    ? 'active' : 'disabled'
+                            }`}
+                            disabled={activeTab === 'findId' ? !isIdFindEnabled : !isPasswordResetEnabled}
+                        >
+                            {activeTab === 'findId' ? '아이디 찾기' : '비밀번호 재설정'}
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            {/* 아이디 찾기 결과 모달 */}
+            <ConfirmModal
+                open={resultModal.isOpen && resultModal.type === 'idResult'}
+                title="아이디 찾기 결과"
+                message={`회원님의 아이디는 ${resultModal.data?.loginId} 입니다.`}
+                type={MODAL_TYPES.CONFIRM_CANCEL}
+                confirmText="비밀번호 찾기"
+                cancelText="로그인하기"
+                onConfirm={handlePasswordFindRedirect}
+                onCancel={handleLoginRedirect}
+            />
+
+            {/* 비밀번호 재설정 완료 모달 */}
+            <ConfirmModal
+                open={resultModal.isOpen && resultModal.type === 'passwordResult'}
+                title="비밀번호 재설정 완료"
+                message="비밀번호가 성공적으로 변경되었습니다.<br/>새로운 비밀번호로 로그인해주세요."
+                type={MODAL_TYPES.CONFIRM_ONLY}
+                confirmText="로그인하기"
+                onConfirm={handleLoginRedirect}
+            />
+        </div>
+    );
+};
+
+export default FindAccount;

--- a/src/app/(user)/login/page.jsx
+++ b/src/app/(user)/login/page.jsx
@@ -174,9 +174,9 @@ export default function Login() {
                 <div className="login-links">
                     <Link href="/signup" className="signup-link">계정이 없으신가요? 회원가입</Link>
                     <div className="find-links">
-                        <a href="#" className="find-link">아이디 찾기</a>
+                        <Link href="/find-account?tab=findId" className="find-link">아이디 찾기</Link>
                         <span className="divider"> | </span>
-                        <a href="#" className="find-link">비밀번호 찾기</a>
+                        <Link href="/find-account?tab=findPassword" className="find-link">비밀번호 찾기</Link>
                     </div>
                 </div>
             </div>

--- a/src/app/ClientLayout.jsx
+++ b/src/app/ClientLayout.jsx
@@ -6,7 +6,7 @@ import { usePathname } from "next/navigation";
 import Header from "@/components/common/Header";
 import Footer from "@/components/common/Footer";
 
-const noLayoutPaths = ["/login", "/signup", "/signup/complete", "/additional-info"]; // 필요 경로 추가
+const noLayoutPaths = ["/login", "/signup", "/signup/complete", "/additional-info", "/find-account"]; // 필요 경로 추가
 
 function LayoutContent({ children }) {
   const pathname = usePathname();


### PR DESCRIPTION
## 🎯 구현 기능

### ✅ 아이디 찾기
- 이름 + 이메일 입력으로 계정 확인
- 실시간 입력값 검증
- 결과 모달로 아이디 표시

### ✅ 비밀번호 찾기  
- 아이디 + 이메일로 계정 확인
- 새 비밀번호 설정 (강도 검증 포함)
- 재설정 완료 모달

### ✅ 기술적 구현
- 단일 페이지에서 탭으로 기능 구분
- URL 파라미터 지원 (`?tab=id`, `?tab=password`)
- 로그인 페이지에서 직접 연결
- 헤더/푸터 제거 (독립 레이아웃)
- localStorage 연동으로 실제 데이터 활용

## 📁 변경 파일
- `/app/(user)/find-account/page.jsx` (신규)
- `/app/(user)/find-account/find-account.css` (신규)  
- `/app/(user)/components/emailUtils.js` (신규)
- `ClientLayout.jsx` (noLayoutPaths 추가)