### PR TITLE
feat: 비밀번호 변경 사이드바 구현

### DIFF
--- a/src/app/(user)/mypage/page.jsx
+++ b/src/app/(user)/mypage/page.jsx
@@ -3,6 +3,7 @@
 import React, { useState } from "react";
 import "./mypage.css";
 import ProfileEdit from "@/app/(user)/profile-edit/page";
+import PasswordChange from "@/app/(user)/password-change/page";
 import MyReviewList from "@/app/review/components/MyReviewList";
 import UserReviewList from "@/app/review/components/UserReviewList";
 import ProductCard from "@/components/common/ProductCard";
@@ -15,6 +16,7 @@ const MyPage = () => {
   const [activeTab, setActiveTab] = useState("");
   const [dashboardTab, setDashboardTab] = useState("purchase");
   const { open: openProfileEditSidebar } = useSidebar("profile-edit");
+  const { open: openPasswordChangeSidebar } = useSidebar("password-change");
   const { open: openLocationSidebar, isOpen: isLocationSidebarOpen } = useSidebar("location-management");
   const { open: openWishlistSidebar, isOpen: isWishlistSidebarOpen } = useSidebar("wishlist");
   const { open: openWidthdrawalSidebar, isOpen: isWidthdrawalSidebarOpen } = useSidebar("withdrawal");
@@ -67,6 +69,11 @@ const MyPage = () => {
       status: "USED",
     },
   ];
+  const dummyReviews = [
+    { id: 1, content: "좋은 거래였습니다" },
+    { id: 2, content: "상품 상태 좋아요" },
+    { id: 3, content: "친절하게 거래해주셨어요" },
+  ];
 
   const renderProfileSection = () => (
     <div className="profile-section">
@@ -117,9 +124,7 @@ const MyPage = () => {
             </div>
             <div className="transaction-item">
               <span className="transaction-label">작성 리뷰</span>
-              <span className="transaction-value" onClick={() => setUserReviewOpen(true)} style={{ cursor: "pointer" }}>
-                3
-              </span>
+              <span className="transaction-value">{dummyReviews.length}</span>
               <span className="transaction-unit">개</span>
             </div>
           </div>
@@ -220,7 +225,7 @@ const MyPage = () => {
             <h3 className="menu-title">내 정보</h3>
             <div className="menu-items">
               <button onClick={openProfileEditSidebar}>프로필 수정</button>
-              <button onClick={() => setActiveTab("password-change")}>비밀번호 변경</button>
+              <button onClick={openPasswordChangeSidebar}>비밀번호 변경</button>
               <button onClick={openLocationSidebar}>거래지역 관리</button>
               <button onClick={() => setActiveTab("child-management")}>자녀 관리</button>
               <button
@@ -268,6 +273,7 @@ const MyPage = () => {
 
       {/* 사이드바들 */}
       <ProfileEdit />
+      <PasswordChange />
       <MyReviewList open={reviewOpen} onClose={() => setReviewOpen(false)} />
       <UserReviewList open={userReviewOpen} onClose={() => setUserReviewOpen(false)} />
       <TradingAreaManagement />

--- a/src/app/(user)/password-change/page.jsx
+++ b/src/app/(user)/password-change/page.jsx
@@ -1,0 +1,260 @@
+"use client";
+
+import React, { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import Sidebar from "@/components/common/Sidebar";
+import ConfirmModal, { MODAL_TYPES } from "@/components/common/ConfirmModal";
+import { validatePasswordStrength, validatePasswordMatch, PASSWORD_CONFIG } from '@/app/(user)/components/passwordUtils';
+import './password-change.css';
+
+const PasswordChange = () => {
+    const router = useRouter();
+
+    const [formData, setFormData] = useState({
+        currentPassword: '',
+        newPassword: '',
+        confirmPassword: ''
+    });
+
+    const [validationStates, setValidationStates] = useState({
+        currentPassword: { status: 'default', message: '', checked: false },
+        newPassword: { status: 'default', message: '' },
+        confirmPassword: { status: 'default', message: '' }
+    });
+
+    const [isLoading, setIsLoading] = useState(false);
+    const [isCompleteModalOpen, setIsCompleteModalOpen] = useState(false);
+    const [isPasswordChanged, setIsPasswordChanged] = useState(false); // 추가
+
+    // 현재 비밀번호 확인 (API 호출 시뮬레이션)
+    const verifyCurrentPassword = async (password) => {
+        return new Promise(resolve => {
+            setTimeout(() => {
+                // 실제로는 API 호출로 현재 비밀번호 확인
+                const isCorrect = password === 'correct123'; // 임시 비밀번호
+                resolve({
+                    isValid: isCorrect,
+                    message: isCorrect ? '현재 비밀번호가 확인되었습니다' : '현재 비밀번호가 일치하지 않습니다'
+                });
+            }, 1000);
+        });
+    };
+
+    // 비밀번호 유효성 검사 (유틸리티 사용)
+    // 비밀번호 확인 검사 (유틸리티 사용)
+
+    const handleInputChange = (e) => {
+        const { name, value } = e.target;
+        setFormData(prev => ({ ...prev, [name]: value }));
+
+        // 현재 비밀번호 입력 시 확인 상태 초기화
+        if (name === 'currentPassword' && validationStates.currentPassword.checked) {
+            setValidationStates(prev => ({
+                ...prev,
+                currentPassword: { status: 'default', message: '', checked: false }
+            }));
+        }
+
+        // 실시간 검증
+        if (name === 'newPassword') {
+            const validation = validatePasswordStrength(value);
+            setValidationStates(prev => ({
+                ...prev,
+                newPassword: {
+                    status: value.trim() === '' ? 'default' : (validation.isValid ? 'success' : 'error'),
+                    message: value.trim() === '' ? '' : validation.message
+                }
+            }));
+
+            // 새 비밀번호가 변경되면 확인 비밀번호도 다시 검증
+            if (formData.confirmPassword) {
+                const confirmValidation = validatePasswordMatch(value, formData.confirmPassword);
+                setValidationStates(prev => ({
+                    ...prev,
+                    confirmPassword: {
+                        status: confirmValidation.isValid ? 'success' : 'error',
+                        message: confirmValidation.message
+                    }
+                }));
+            }
+        }
+
+        if (name === 'confirmPassword') {
+            const validation = validatePasswordMatch(formData.newPassword, value);
+            setValidationStates(prev => ({
+                ...prev,
+                confirmPassword: {
+                    status: value.trim() === '' ? 'default' : (validation.isValid ? 'success' : 'error'),
+                    message: value.trim() === '' ? '' : validation.message
+                }
+            }));
+        }
+    };
+
+    // 현재 비밀번호 확인
+    const handleCurrentPasswordVerify = async () => {
+        if (!formData.currentPassword.trim()) {
+            setValidationStates(prev => ({
+                ...prev,
+                currentPassword: { status: 'error', message: '현재 비밀번호를 입력해주세요', checked: false }
+            }));
+            return;
+        }
+
+        setValidationStates(prev => ({
+            ...prev,
+            currentPassword: { status: 'loading', message: '🔄 확인 중...', checked: false }
+        }));
+
+        try {
+            const result = await verifyCurrentPassword(formData.currentPassword);
+            setValidationStates(prev => ({
+                ...prev,
+                currentPassword: {
+                    status: result.isValid ? 'success' : 'error',
+                    message: result.isValid ? '✅ ' + result.message : '❌ ' + result.message,
+                    checked: result.isValid
+                }
+            }));
+        } catch (error) {
+            setValidationStates(prev => ({
+                ...prev,
+                currentPassword: { status: 'error', message: '❌ 확인 중 오류가 발생했습니다', checked: false }
+            }));
+        }
+    };
+
+    // 비밀번호 변경 실행
+    const handlePasswordChange = async () => {
+        setIsLoading(true);
+
+        // 실제로는 API 호출
+        setTimeout(() => {
+            console.log('비밀번호 변경 완료:', {
+                currentPassword: formData.currentPassword,
+                newPassword: formData.newPassword
+            });
+            setIsLoading(false);
+            setIsPasswordChanged(true); // 변경 완료 상태 설정
+            setIsCompleteModalOpen(true);
+        }, 1000);
+    };
+
+    const handleCompleteModalClose = () => {
+        setIsCompleteModalOpen(false);
+        // 필요시 페이지 이동 또는 폼 초기화
+    };
+
+    // 변경 버튼 활성화 조건
+    const isChangeEnabled =
+        !isPasswordChanged && // 이미 변경되었으면 비활성화
+        validationStates.currentPassword.checked &&
+        validationStates.newPassword.status === 'success' &&
+        validationStates.confirmPassword.status === 'success' &&
+        !isLoading;
+
+    return (
+        <>
+            <Sidebar
+                sidebarKey="password-change"
+                title="비밀번호 변경"
+                trigger={<span style={{display: 'none'}}>숨김</span>}
+                onBack={true}
+            >
+                <div className="password-change-content">
+                    <div className="top-section">
+                        {/* 현재 비밀번호 */}
+                        <div className="input-field">
+                            <div className="input-with-verify">
+                                <input
+                                    type="password"
+                                    name="currentPassword"
+                                    value={formData.currentPassword}
+                                    onChange={handleInputChange}
+                                    className={`password-input ${validationStates.currentPassword.status === 'error' ? 'error' : ''}`}
+                                    placeholder="현재 비밀번호를 입력하세요"
+                                />
+                                <button
+                                    type="button"
+                                    className="verify-btn"
+                                    onClick={handleCurrentPasswordVerify}
+                                    disabled={isLoading || validationStates.currentPassword.checked}
+                                >
+                                    {validationStates.currentPassword.status === 'loading' ? '확인중...' :
+                                        validationStates.currentPassword.checked ? '✓ 확인됨' : '확인'}
+                                </button>
+                            </div>
+                            {validationStates.currentPassword.message && (
+                                <div className={`message ${validationStates.currentPassword.status === 'success' ? 'success' : 'error'}`}>
+                                    {validationStates.currentPassword.message}
+                                </div>
+                            )}
+                        </div>
+
+                        {/* 안내 메시지 제거 */}
+
+                        {/* 새 비밀번호 */}
+                        <div className="input-field">
+                            <input
+                                type="password"
+                                name="newPassword"
+                                value={formData.newPassword}
+                                onChange={handleInputChange}
+                                className={`password-input ${validationStates.newPassword.status === 'error' ? 'error' : ''}`}
+                                placeholder={PASSWORD_CONFIG.placeholder}
+                                maxLength={PASSWORD_CONFIG.maxLength}
+                            />
+                            {validationStates.newPassword.message && (
+                                <div className={`message ${validationStates.newPassword.status === 'success' ? 'success' : 'error'}`}>
+                                    {validationStates.newPassword.message}
+                                </div>
+                            )}
+                        </div>
+
+                        {/* 새 비밀번호 재입력 */}
+                        <div className="input-field">
+                            <input
+                                type="password"
+                                name="confirmPassword"
+                                value={formData.confirmPassword}
+                                onChange={handleInputChange}
+                                className={`password-input ${validationStates.confirmPassword.status === 'error' ? 'error' : ''}`}
+                                placeholder={PASSWORD_CONFIG.confirmPlaceholder}
+                                maxLength={PASSWORD_CONFIG.maxLength}
+                            />
+                            {validationStates.confirmPassword.message && (
+                                <div className={`message ${validationStates.confirmPassword.status === 'success' ? 'success' : 'error'}`}>
+                                    {validationStates.confirmPassword.message}
+                                </div>
+                            )}
+                        </div>
+                    </div>
+
+                    {/* 버튼 섹션 */}
+                    <div className="bottom-section">
+                        <button
+                            className={`action-btn primary ${isChangeEnabled ? 'enabled' : 'disabled'}`}
+                            onClick={handlePasswordChange}
+                            disabled={!isChangeEnabled}
+                        >
+                            {isPasswordChanged ? '비밀번호 변경 완료' : (isLoading ? '변경 중...' : '비밀번호 변경')}
+                        </button>
+                    </div>
+                </div>
+            </Sidebar>
+
+            {/* 비밀번호 변경 완료 모달 */}
+            <ConfirmModal
+                open={isCompleteModalOpen}
+                title="비밀번호 변경 완료"
+                message="비밀번호가 성공적으로 변경되었습니다."
+                onConfirm={handleCompleteModalClose}
+                onCancel={handleCompleteModalClose}
+                type={MODAL_TYPES.CONFIRM_ONLY}
+                confirmText="확인"
+            />
+        </>
+    );
+};
+
+export default PasswordChange;

--- a/src/app/(user)/password-change/password-change.css
+++ b/src/app/(user)/password-change/password-change.css
@@ -1,0 +1,244 @@
+/* Password Change Content */
+.password-change-content {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    padding: 20px;
+    font-family: 'Pretendard Variable', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    justify-content: space-between;
+    min-height: 500px;
+}
+
+/* Main Form Container - 흰색 박스 */
+.top-section {
+    background: #FFFFFF;
+    border: 1px solid #DDDDDD;
+    border-radius: 8px;
+    padding: 30px 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-bottom: 20px;
+}
+
+/* Bottom Section - 버튼 영역 */
+.bottom-section {
+    display: flex !important;
+    flex-direction: column;
+    gap: 12px;
+    margin-top: 20px;
+    padding: 0 20px 20px 20px;
+    width: 100%;
+}
+
+/* Input Field */
+.input-field {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+/* Input with Verify Button */
+.input-with-verify {
+    display: flex;
+    gap: 8px;
+    width: 100%;
+}
+
+/* Password Input */
+.password-input {
+    width: 100%;
+    height: 46px;
+    border: 1px solid #CBD5E1;
+    border-radius: 8px;
+    padding: 0 16px;
+    font-family: 'Inter', sans-serif;
+    font-weight: 400;
+    font-size: 14px;
+    line-height: 1.21;
+    color: #000000;
+    background-color: #FFFFFF;
+    outline: none;
+    transition: border-color 0.3s ease;
+    box-sizing: border-box;
+}
+
+.input-with-verify .password-input {
+    flex: 1;
+}
+
+.password-input::placeholder {
+    color: #94A3B8;
+}
+
+.password-input:focus {
+    border-color: #85B3EB;
+    box-shadow: 0 0 0 3px rgba(133, 179, 235, 0.1);
+}
+
+.password-input.error {
+    border-color: #EF4444;
+}
+
+/* Verify Button */
+.verify-btn {
+    width: 80px;
+    height: 46px;
+    background-color: #85B3EB;
+    border: none;
+    border-radius: 8px;
+    font-family: 'Pretendard Variable', sans-serif;
+    font-weight: 500;
+    font-size: 14px;
+    color: #FFFFFF;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    flex-shrink: 0;
+    white-space: nowrap;
+}
+
+.verify-btn:hover:not(:disabled) {
+    background-color: #6B9AFF;
+}
+
+.verify-btn:disabled {
+    background-color: #CBD5E1;
+    color: #94A3B8;
+    cursor: not-allowed;
+}
+
+/* Message Styles */
+.message {
+    font-family: 'Inter', sans-serif;
+    font-size: 12px;
+    margin-top: 4px;
+    font-weight: 500;
+}
+
+.message.error {
+    color: #EF4444;
+}
+
+.message.success {
+    color: #10B981;
+}
+
+/* Help Message */
+.help-message {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    justify-content: center;
+    margin: 20px 0 10px 0;
+    padding: 0;
+}
+
+.help-icon {
+    font-size: 16px;
+}
+
+.help-text {
+    font-family: 'Pretendard Variable', sans-serif;
+    font-weight: 400;
+    font-size: 14px;
+    color: #94A3B8;
+}
+
+/* Action Buttons */
+.action-btn {
+    display: block !important;
+    width: 100% !important;
+    height: 48px !important;
+    border: none;
+    border-radius: 8px;
+    font-family: 'Pretendard Variable', sans-serif;
+    font-weight: 500;
+    font-size: 16px;
+    text-align: center;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    box-sizing: border-box;
+}
+
+/* Primary Button States */
+.action-btn.primary {
+    background-color: #DDDDDD !important;
+    color: #999999 !important;
+    cursor: not-allowed;
+}
+
+.action-btn.primary.enabled {
+    background-color: #85B3EB !important;
+    color: #FFFFFF !important;
+    cursor: pointer;
+}
+
+.action-btn.primary.enabled:hover {
+    background-color: #6B9AFF !important;
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+    .password-change-content {
+        padding: 16px;
+        min-height: 450px;
+    }
+
+    .top-section {
+        padding: 24px 16px;
+    }
+
+    .bottom-section {
+        padding: 0 16px 16px 16px !important;
+        margin-top: 16px;
+    }
+
+    .input-with-verify {
+        flex-direction: column;
+        gap: 8px;
+    }
+
+    .verify-btn {
+        width: 100%;
+    }
+
+    .password-input,
+    .verify-btn {
+        height: 44px;
+        font-size: 14px;
+    }
+
+    .action-btn {
+        height: 46px !important;
+        font-size: 15px;
+    }
+}
+
+@media (max-width: 480px) {
+    .password-change-content {
+        padding: 12px;
+        min-height: 400px;
+    }
+
+    .top-section {
+        padding: 20px 12px;
+        gap: 14px;
+    }
+
+    .bottom-section {
+        gap: 10px;
+        padding: 0 12px 12px 12px !important;
+    }
+
+    .password-input,
+    .verify-btn {
+        height: 42px;
+        font-size: 13px;
+    }
+
+    .action-btn {
+        height: 44px !important;
+        font-size: 14px;
+    }
+}


### PR DESCRIPTION
## 📋 구현 내용
- 마이페이지에서 접근 가능한 비밀번호 변경 사이드바 추가
- 현재 비밀번호 확인 기능 (API 시뮬레이션)
- 새 비밀번호 검증 (8~16자, 영문+숫자+특수문자 필수)
- 비밀번호 재입력 일치 확인
- 실시간 입력값 검증 및 피드백
- 변경 완료 후 버튼 비활성화 처리

## 🔧 기술 구현
- 기존 passwordUtils.js 활용한 강화된 검증 로직
- Sidebar 컴포넌트와 useSidebar 훅 활용
- ConfirmModal을 통한 완료 알림

## 🔄 수정 사항
- 마이페이지 작성 리뷰 개수에서 클릭 이벤트 제거
- dummyReviews 배열로 동적 개수 표시로 변경 (API 연동 준비)