### PR TITLE
feat: 자녀 관리 사이드바 및 마이페이지 자녀 정보 표시 구현

### DIFF
--- a/src/app/(user)/child-management/child-management.css
+++ b/src/app/(user)/child-management/child-management.css
@@ -1,0 +1,270 @@
+/* Child Management Content */
+.child-management-content {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    padding: 20px;
+    font-family: 'Pretendard Variable', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    justify-content: space-between;
+    min-height: 500px;
+}
+
+/* Top Section */
+.top-section {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    margin-bottom: 20px;
+}
+
+/* Info Message */
+.info-message {
+    font-size: 14px;
+    font-weight: 400;
+    color: #666666;
+    margin: 0;
+    text-align: center;
+    padding: 12px 16px;
+    background-color: #F8F9FA;
+    border-radius: 8px;
+    border: 1px solid #E9ECEF;
+}
+
+/* Child Forms Container */
+.child-forms {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+/* Individual Child Form */
+.child-form {
+    background: #FFFFFF;
+    border: 1px solid #DDDDDD;
+    border-radius: 8px;
+    padding: 20px;
+    position: relative;
+}
+
+/* Form Header */
+.form-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 20px;
+}
+
+.form-title {
+    font-family: 'Pretendard Variable', sans-serif;
+    font-weight: 600;
+    font-size: 16px;
+    color: #1F2937;
+    margin: 0;
+}
+
+.remove-btn {
+    width: 24px;
+    height: 24px;
+    background: none;
+    border: none;
+    color: #9CA3AF;
+    font-size: 16px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 4px;
+    transition: all 0.2s ease;
+}
+
+.remove-btn:hover {
+    background-color: #FEE2E2;
+    color: #EF4444;
+}
+
+/* Input Field */
+.input-field {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-bottom: 16px;
+}
+
+.input-label {
+    font-family: 'Pretendard Variable', sans-serif;
+    font-weight: 500;
+    font-size: 14px;
+    color: #374151;
+}
+
+/* Child Input */
+.child-input {
+    width: 100%;
+    height: 46px;
+    border: 1px solid #CBD5E1;
+    border-radius: 8px;
+    padding: 0 16px;
+    font-family: 'Inter', sans-serif;
+    font-weight: 400;
+    font-size: 14px;
+    line-height: 1.21;
+    color: #000000;
+    background-color: #FFFFFF;
+    outline: none;
+    transition: border-color 0.3s ease;
+    box-sizing: border-box;
+}
+
+.child-input::placeholder {
+    color: #94A3B8;
+}
+
+.child-input:focus {
+    border-color: #85B3EB;
+    box-shadow: 0 0 0 3px rgba(133, 179, 235, 0.1);
+}
+
+/* Date Input Specific */
+.date-input {
+    font-family: 'Inter', sans-serif;
+}
+
+.date-input::-webkit-calendar-picker-indicator {
+    cursor: pointer;
+    opacity: 0.6;
+}
+
+.date-input::-webkit-calendar-picker-indicator:hover {
+    opacity: 1;
+}
+
+/* Input Help Text */
+.input-help {
+    font-family: 'Inter', sans-serif;
+    font-size: 12px;
+    color: #6B7280;
+    font-weight: 400;
+}
+
+/* Add Child Section */
+.add-child-section {
+    display: flex;
+    justify-content: center;
+    margin-top: 10px;
+}
+
+.add-child-btn {
+    background: none;
+    border: none;
+    color: #85B3EB;
+    font-family: 'Pretendard Variable', sans-serif;
+    font-weight: 500;
+    font-size: 14px;
+    cursor: pointer;
+    padding: 8px 16px;
+    border-radius: 6px;
+    transition: all 0.2s ease;
+}
+
+.add-child-btn:hover {
+    background-color: #F1F7FF;
+    color: #6B9AFF;
+    font-weight: 600;
+}
+
+/* Bottom Section - 버튼 영역 */
+.bottom-section {
+    display: flex !important;
+    flex-direction: column;
+    gap: 12px;
+    margin-top: 20px;
+    padding: 0 20px 20px 20px;
+    width: 100%;
+}
+
+/* Action Buttons */
+.action-btn {
+    display: block !important;
+    width: 100% !important;
+    height: 48px !important;
+    border: none;
+    border-radius: 8px;
+    font-family: 'Pretendard Variable', sans-serif;
+    font-weight: 500;
+    font-size: 16px;
+    text-align: center;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    box-sizing: border-box;
+}
+
+/* Primary Button States */
+.action-btn.primary {
+    background-color: #DDDDDD !important;
+    color: #999999 !important;
+    cursor: not-allowed;
+}
+
+.action-btn.primary.enabled {
+    background-color: #85B3EB !important;
+    color: #FFFFFF !important;
+    cursor: pointer;
+}
+
+.action-btn.primary.enabled:hover {
+    background-color: #6B9AFF !important;
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+    .child-management-content {
+        padding: 16px;
+        min-height: 450px;
+    }
+
+    .child-form {
+        padding: 16px;
+    }
+
+    .bottom-section {
+        padding: 0 16px 16px 16px !important;
+        margin-top: 16px;
+    }
+
+    .child-input {
+        height: 44px;
+        font-size: 14px;
+    }
+
+    .action-btn {
+        height: 46px !important;
+        font-size: 15px;
+    }
+}
+
+@media (max-width: 480px) {
+    .child-management-content {
+        padding: 12px;
+        min-height: 400px;
+    }
+
+    .child-form {
+        padding: 12px;
+    }
+
+    .bottom-section {
+        gap: 10px;
+        padding: 0 12px 12px 12px !important;
+    }
+
+    .child-input {
+        height: 42px;
+        font-size: 13px;
+    }
+
+    .action-btn {
+        height: 44px !important;
+        font-size: 14px;
+    }
+}

--- a/src/app/(user)/child-management/page.jsx
+++ b/src/app/(user)/child-management/page.jsx
@@ -1,0 +1,234 @@
+"use client";
+
+import React, { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import Sidebar from "@/components/common/Sidebar";
+import ConfirmModal, { MODAL_TYPES } from "@/components/common/ConfirmModal";
+import './child-management.css';
+
+const ChildManagement = () => {
+    const router = useRouter();
+
+    // 현재 저장된 자녀 정보 (실제로는 API에서 가져올 데이터)
+    const [savedChildren] = useState([
+        // { id: 1, nickname: '첫째', birthDate: '2020-03-15', age: 4 },
+        // { id: 2, nickname: '둘째', birthDate: '2022-07-20', age: 2 }
+    ]);
+
+    const [childForms, setChildForms] = useState([
+        { id: Date.now(), nickname: '', birthDate: '', age: null }
+    ]);
+
+    const [isLoading, setIsLoading] = useState(false);
+    const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
+    const [isCompleteModalOpen, setIsCompleteModalOpen] = useState(false);
+    const [isChildrenSaved, setIsChildrenSaved] = useState(false);
+
+    // 나이 계산 함수
+    const calculateAge = (birthDate) => {
+        if (!birthDate) return null;
+
+        const today = new Date();
+        const birth = new Date(birthDate);
+        let age = today.getFullYear() - birth.getFullYear();
+        const monthDiff = today.getMonth() - birth.getMonth();
+
+        if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < birth.getDate())) {
+            age--;
+        }
+
+        return age;
+    };
+
+    // 입력값 변경 핸들러
+    const handleInputChange = (id, field, value) => {
+        // 입력값이 변경되면 저장 상태 초기화
+        setIsChildrenSaved(false);
+
+        setChildForms(prev => prev.map(form => {
+            if (form.id === id) {
+                const updatedForm = { ...form, [field]: value };
+
+                // 생년월일이 변경되면 자동으로 나이 계산
+                if (field === 'birthDate') {
+                    updatedForm.age = calculateAge(value);
+                }
+
+                return updatedForm;
+            }
+            return form;
+        }));
+    };
+
+    // 자녀 폼 추가
+    const addChildForm = () => {
+        if (childForms.length < 2) {
+            setChildForms(prev => [
+                ...prev,
+                { id: Date.now(), nickname: '', birthDate: '', age: null }
+            ]);
+        }
+    };
+
+    // 자녀 폼 삭제
+    const removeChildForm = (id) => {
+        if (childForms.length > 1) {
+            setIsChildrenSaved(false);
+            setChildForms(prev => prev.filter(form => form.id !== id));
+        }
+    };
+
+    // 저장 버튼 클릭
+    const handleSaveClick = () => {
+        setIsConfirmModalOpen(true);
+    };
+
+    // 저장 확인
+    const handleSaveConfirm = async () => {
+        setIsConfirmModalOpen(false);
+        setIsLoading(true);
+
+        // 실제로는 API 호출
+        setTimeout(() => {
+            console.log('저장된 자녀 정보:', childForms);
+            setIsLoading(false);
+            setIsChildrenSaved(true);
+            setIsCompleteModalOpen(true);
+        }, 1000);
+    };
+
+    const handleSaveCancel = () => {
+        setIsConfirmModalOpen(false);
+    };
+
+    const handleCompleteModalClose = () => {
+        setIsCompleteModalOpen(false);
+    };
+
+    // 저장 버튼 활성화 조건
+    const isSaveEnabled = !isChildrenSaved &&
+        childForms.length > 0 &&
+        childForms.every(form => form.nickname.trim() !== '' && form.birthDate !== '') &&
+        !isLoading;
+
+    return (
+        <>
+            <Sidebar
+                sidebarKey="child-management"
+                title="자녀목록 관리"
+                trigger={<span style={{display: 'none'}}>숨김</span>}
+                onBack={true}
+            >
+                <div className="child-management-content">
+                    <div className="top-section">
+                        {/* 안내 메시지 */}
+                        <div className="info-message">
+                            자녀는 최대 2명까지 저장가능합니다.
+                        </div>
+
+                        {/* 자녀 폼들 */}
+                        <div className="child-forms">
+                            {childForms.map((form, index) => (
+                                <div key={form.id} className="child-form">
+                                    <div className="form-header">
+                                        <h4 className="form-title">자녀목록 추가</h4>
+                                        {childForms.length > 1 && (
+                                            <button
+                                                type="button"
+                                                className="remove-btn"
+                                                onClick={() => removeChildForm(form.id)}
+                                            >
+                                                ✕
+                                            </button>
+                                        )}
+                                    </div>
+
+                                    {/* 애칭 입력 */}
+                                    <div className="input-field">
+                                        <label className="input-label">애칭 *</label>
+                                        <input
+                                            type="text"
+                                            value={form.nickname}
+                                            onChange={(e) => handleInputChange(form.id, 'nickname', e.target.value)}
+                                            className="child-input"
+                                            placeholder="우리 아이를 어떻게 부르시나요?"
+                                            maxLength={10}
+                                        />
+                                        <div className="input-help">최대 10글자까지 입력 가능해요</div>
+                                    </div>
+
+                                    {/* 생년월일 입력 */}
+                                    <div className="input-field">
+                                        <label className="input-label">생년월일 *</label>
+                                        <input
+                                            type="date"
+                                            value={form.birthDate}
+                                            onChange={(e) => handleInputChange(form.id, 'birthDate', e.target.value)}
+                                            className="child-input date-input"
+                                            max={new Date().toISOString().split('T')[0]} // 오늘 날짜까지만 선택 가능
+                                        />
+                                        <div className="input-help">
+                                            {form.age !== null ?
+                                                `생년월일을 선택하면 자동으로 나이를 계산해 드려요 (현재 ${form.age}세)` :
+                                                '생년월일을 선택하면 자동으로 나이를 계산해 드려요'
+                                            }
+                                        </div>
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+
+                        {/* 추가 버튼 */}
+                        {childForms.length < 2 && (
+                            <div className="add-child-section">
+                                <button
+                                    type="button"
+                                    className="add-child-btn"
+                                    onClick={addChildForm}
+                                >
+                                    + 추가
+                                </button>
+                            </div>
+                        )}
+                    </div>
+
+                    {/* 버튼 섹션 */}
+                    <div className="bottom-section">
+                        <button
+                            className={`action-btn primary ${isSaveEnabled ? 'enabled' : 'disabled'}`}
+                            onClick={handleSaveClick}
+                            disabled={!isSaveEnabled}
+                        >
+                            {isChildrenSaved ? '자녀 정보 저장 완료' : (isLoading ? '저장 중...' : '자녀 정보 추가')}
+                        </button>
+                    </div>
+                </div>
+            </Sidebar>
+
+            {/* 저장 확인 모달 */}
+            <ConfirmModal
+                open={isConfirmModalOpen}
+                title="자녀 정보 저장"
+                message="입력한 자녀 정보를 저장하시겠습니까?"
+                onConfirm={handleSaveConfirm}
+                onCancel={handleSaveCancel}
+                type={MODAL_TYPES.CONFIRM_CANCEL}
+                confirmText="저장"
+                cancelText="취소"
+            />
+
+            {/* 저장 완료 모달 */}
+            <ConfirmModal
+                open={isCompleteModalOpen}
+                title="자녀 정보 저장 완료"
+                message="자녀 정보가 성공적으로 저장되었습니다."
+                onConfirm={handleCompleteModalClose}
+                onCancel={handleCompleteModalClose}
+                type={MODAL_TYPES.CONFIRM_ONLY}
+                confirmText="확인"
+            />
+        </>
+    );
+};
+
+export default ChildManagement;

--- a/src/app/(user)/mypage/mypage.css
+++ b/src/app/(user)/mypage/mypage.css
@@ -208,6 +208,58 @@
     flex-direction: column;
 }
 
+/* 자녀 정보 표시 */
+.children-display {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    width: 100%;
+    height: 100%;           /* 부모 높이에 맞춤 */
+    justify-content: center; /* 세로 중앙 정렬 */
+    padding: 16px;          /* 내부 여백 */
+    box-sizing: border-box; /* 패딩 포함 계산 */
+}
+
+.child-info-card {
+    width: 100%;
+    border: 1px solid #E9ECEF;
+    border-radius: 12px;
+    text-align: center;
+}
+
+.child-header {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    margin: 12px;
+}
+
+.child-emoji {
+    font-size: 20px;
+}
+
+.child-nickname {
+    font-weight: 600;
+    font-size: 18px;
+    color: #000000;
+}
+
+.child-birth-date {
+    font-size: 14px;
+    color: #666666;
+    margin-bottom: 8px;
+    text-align: center;
+}
+
+.child-current-age {
+    font-size: 16px;
+    font-weight: 600;
+    color: #6B9AFF;
+    align-items: center;
+    text-align: center;
+}
+
 /* Transaction Card */
 .transaction-card {
     background: #FFFFFF;
@@ -373,76 +425,4 @@
     text-align: center;
     color: #999;
     padding: 40px 0;
-}
-
-/* Responsive Design */
-@media (max-width: 1200px) {
-    .main-content {
-        flex-direction: column;
-        gap: 30px;
-    }
-
-    .sidebar {
-        width: 100%;
-        flex-direction: row;
-        justify-content: space-around;
-    }
-
-    .profile-section {
-        flex-direction: column;
-    }
-
-    .profile-card {
-        width: 100%;
-    }
-
-    .right-cards {
-        flex-direction: row;
-        gap: 0;
-    }
-}
-
-@media (max-width: 768px) {
-    .mypage-container {
-        padding: 0 10px;
-        width: 100%;
-    }
-
-    .main-content {
-        padding: 20px 0;
-    }
-
-    .tab-item {
-        padding: 10px 25px;
-        font-size: 14px;
-    }
-
-    .item-count {
-        font-size: 12px;
-    }
-
-    .profile-card,
-    .child-card,
-    .transaction-card {
-        padding: 20px 15px;
-    }
-
-    .card-title {
-        font-size: 14px;
-        top: -10px;
-        left: 15px;
-    }
-
-    .right-cards {
-        flex-direction: column;
-    }
-
-    .child-card {
-        border-radius: 12px 12px 0 0;
-        border-bottom: 1px solid #E9ECEF;
-    }
-
-    .transaction-card {
-        border-radius: 0 0 12px 12px;
-    }
 }

--- a/src/app/(user)/mypage/page.jsx
+++ b/src/app/(user)/mypage/page.jsx
@@ -2,15 +2,16 @@
 
 import React, { useState } from "react";
 import "./mypage.css";
+import { useSidebar } from "@/hooks/useSidebar";
 import ProfileEdit from "@/app/(user)/profile-edit/page";
 import PasswordChange from "@/app/(user)/password-change/page";
-import MyReviewList from "@/app/review/components/MyReviewList";
-import UserReviewList from "@/app/review/components/UserReviewList";
 import ProductCard from "@/components/common/ProductCard";
 import TradingAreaManagement from "@/app/(user)/location-management/page";
+import ChildManagement from "@/app/(user)/child-management/page";
 import WishlistSidebar from "@/components/common/WishlistSidebar";
-import { useSidebar } from "@/hooks/useSidebar";
 import WithdrawlSidebar from "../withdrawal/components/withdrawlSidebar";
+import MyReviewList from "@/app/review/components/MyReviewList";
+import UserReviewList from "@/app/review/components/UserReviewList";
 
 const MyPage = () => {
   const [activeTab, setActiveTab] = useState("");
@@ -18,10 +19,16 @@ const MyPage = () => {
   const { open: openProfileEditSidebar } = useSidebar("profile-edit");
   const { open: openPasswordChangeSidebar } = useSidebar("password-change");
   const { open: openLocationSidebar, isOpen: isLocationSidebarOpen } = useSidebar("location-management");
+  const { open: openChildManagementSidebar } = useSidebar("child-management");
   const { open: openWishlistSidebar, isOpen: isWishlistSidebarOpen } = useSidebar("wishlist");
   const { open: openWidthdrawalSidebar, isOpen: isWidthdrawalSidebarOpen } = useSidebar("withdrawal");
   const [reviewOpen, setReviewOpen] = useState(false);
   const [userReviewOpen, setUserReviewOpen] = useState(false);
+
+  const dummyChildren = [
+    { id: 1, nickname: '첫째', birthDate: '2023-06-30', age: 2 },
+    { id: 2, nickname: '둘째', birthDate: '2025-03-19', age: 0 }
+  ];
 
   const dummyPurchases = [
     {
@@ -76,117 +83,134 @@ const MyPage = () => {
   ];
 
   const renderProfileSection = () => (
-    <div className="profile-section">
-      <div className="profile-card">
-        <h3 className="card-title">프로필 정보</h3>
-        <div className="profile-content">
-          <div className="profile-avatar"></div>
-          <h2 className="profile-name">멋진맘</h2>
-          <div className="rating">
-            <span className="stars">⭐⭐⭐⭐⭐</span>
-            <span className="rating-score">(4.8)</span>
+      <div className="profile-section">
+        <div className="profile-card">
+          <h3 className="card-title">프로필 정보</h3>
+          <div className="profile-content">
+            <div className="profile-avatar"></div>
+            <h2 className="profile-name">멋진맘</h2>
+            <div className="rating">
+              <span className="stars">⭐⭐⭐⭐⭐</span>
+              <span className="rating-score">(4.8)</span>
+            </div>
+            <div className="location-info">
+              <span className="location-label">거래 지역:</span>
+              <div className="location-tags">
+                <span className="location-tag">서초동</span>
+                <span className="location-tag">양재동</span>
+                <span className="location-tag">반포동</span>
+              </div>
+            </div>
           </div>
-          <div className="location-info">
-            <span className="location-label">거래 지역:</span>
-            <div className="location-tags">
-              <span className="location-tag">서초동</span>
-              <span className="location-tag">양재동</span>
-              <span className="location-tag">반포동</span>
+        </div>
+
+        <div className="right-cards">
+          <div className="child-card">
+            <h3 className="card-title">자녀 정보</h3>
+            <div className="child-content">
+              {dummyChildren.length === 0 ? (
+                  <p className="no-child-info">
+                    등록된 자녀정보가
+                    <br />
+                    없습니다.
+                  </p>
+              ) : (
+                  <div className="children-display">
+                    {dummyChildren.map(child => (
+                        <div key={child.id} className="child-info-card">
+                          <div className="child-header">
+                            <span className="child-emoji">👶</span>
+                            <span className="child-nickname">{child.nickname}</span>
+                          </div>
+                          <div className="child-birth-date">
+                            {new Date(child.birthDate).getFullYear()}년 {new Date(child.birthDate).getMonth() + 1}월 {new Date(child.birthDate).getDate()}일
+                          </div>
+                          <div className="child-current-age">{child.age}세</div>
+                        </div>
+                    ))}
+                  </div>
+              )}
+            </div>
+          </div>
+
+          <div className="transaction-card">
+            <h3 className="card-title">나의 거래 현황</h3>
+            <div className="transaction-content">
+              <div className="transaction-item">
+                <span className="transaction-label">총 구매</span>
+                <span className="transaction-value">{dummyPurchases.length}</span>
+                <span className="transaction-unit">건</span>
+              </div>
+              <div className="transaction-item">
+                <span className="transaction-label">총 판매</span>
+                <span className="transaction-value">{dummySales.length}</span>
+                <span className="transaction-unit">건</span>
+              </div>
+              <div className="transaction-item">
+                <span className="transaction-label">작성 리뷰</span>
+                <span className="transaction-value">{dummyReviews.length}</span>
+                <span className="transaction-unit">개</span>
+              </div>
             </div>
           </div>
         </div>
       </div>
-
-      <div className="right-cards">
-        <div className="child-card">
-          <h3 className="card-title">자녀 정보</h3>
-          <div className="child-content">
-            <p className="no-child-info">
-              등록된 자녀정보가
-              <br />
-              없습니다.
-            </p>
-          </div>
-        </div>
-
-        <div className="transaction-card">
-          <h3 className="card-title">나의 거래 현황</h3>
-          <div className="transaction-content">
-            <div className="transaction-item">
-              <span className="transaction-label">총 구매</span>
-              <span className="transaction-value">{dummyPurchases.length}</span>
-              <span className="transaction-unit">건</span>
-            </div>
-            <div className="transaction-item">
-              <span className="transaction-label">총 판매</span>
-              <span className="transaction-value">{dummySales.length}</span>
-              <span className="transaction-unit">건</span>
-            </div>
-            <div className="transaction-item">
-              <span className="transaction-label">작성 리뷰</span>
-              <span className="transaction-value">{dummyReviews.length}</span>
-              <span className="transaction-unit">개</span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
   );
 
   const renderDashboard = () => (
-    <>
-      {renderProfileSection()}
-      <div className="tab-section">
-        <div className="tab-list">
-          <button
-            className={`tab-item ${dashboardTab === "purchase" ? "active" : ""}`}
-            onClick={() => setDashboardTab("purchase")}
-          >
-            구매 상품
-          </button>
-          <button
-            className={`tab-item ${dashboardTab === "sale" ? "active" : ""}`}
-            onClick={() => setDashboardTab("sale")}
-          >
-            판매 상품
-          </button>
+      <>
+        {renderProfileSection()}
+        <div className="tab-section">
+          <div className="tab-list">
+            <button
+                className={`tab-item ${dashboardTab === "purchase" ? "active" : ""}`}
+                onClick={() => setDashboardTab("purchase")}
+            >
+              구매 상품
+            </button>
+            <button
+                className={`tab-item ${dashboardTab === "sale" ? "active" : ""}`}
+                onClick={() => setDashboardTab("sale")}
+            >
+              판매 상품
+            </button>
+          </div>
         </div>
-      </div>
 
-      <div className="tab-content-area">
-        {dashboardTab === "purchase" ? (
-          <>
-            <div className="item-count">총 {dummyPurchases.length} 개</div>
-            {dummyPurchases.length === 0 ? (
-              <div className="empty-state">
-                <p>등록된 구매 상품이 없습니다.</p>
-              </div>
-            ) : (
-              <div className="products-grid">
-                {dummyPurchases.map((product) => (
-                  <ProductCard key={product.id} product={product} size="size1" />
-                ))}
-              </div>
-            )}
-          </>
-        ) : (
-          <>
-            <div className="item-count">총 {dummySales.length} 개</div>
-            {dummySales.length === 0 ? (
-              <div className="empty-state">
-                <p>등록된 판매 상품이 없습니다.</p>
-              </div>
-            ) : (
-              <div className="products-grid">
-                {dummySales.map((product) => (
-                  <ProductCard key={product.id} product={product} size="size1" />
-                ))}
-              </div>
-            )}
-          </>
-        )}
-      </div>
-    </>
+        <div className="tab-content-area">
+          {dashboardTab === "purchase" ? (
+              <>
+                <div className="item-count">총 {dummyPurchases.length} 개</div>
+                {dummyPurchases.length === 0 ? (
+                    <div className="empty-state">
+                      <p>등록된 구매 상품이 없습니다.</p>
+                    </div>
+                ) : (
+                    <div className="products-grid">
+                      {dummyPurchases.map((product) => (
+                          <ProductCard key={product.id} product={product} size="size1" />
+                      ))}
+                    </div>
+                )}
+              </>
+          ) : (
+              <>
+                <div className="item-count">총 {dummySales.length} 개</div>
+                {dummySales.length === 0 ? (
+                    <div className="empty-state">
+                      <p>등록된 판매 상품이 없습니다.</p>
+                    </div>
+                ) : (
+                    <div className="products-grid">
+                      {dummySales.map((product) => (
+                          <ProductCard key={product.id} product={product} size="size1" />
+                      ))}
+                    </div>
+                )}
+              </>
+          )}
+        </div>
+      </>
   );
 
   const renderTabContent = () => {
@@ -195,21 +219,21 @@ const MyPage = () => {
         return renderDashboard();
       case "profile-edit":
         return (
-          <div className="tab-content">
-            <h2>프로필 수정</h2>
-          </div>
+            <div className="tab-content">
+              <h2>프로필 수정</h2>
+            </div>
         );
       case "password-change":
         return (
-          <div className="tab-content">
-            <h2>비밀번호 변경</h2>
-          </div>
+            <div className="tab-content">
+              <h2>비밀번호 변경</h2>
+            </div>
         );
       case "review-management":
         return (
-          <div className="tab-content">
-            <h2>리뷰 관리</h2>
-          </div>
+            <div className="tab-content">
+              <h2>리뷰 관리</h2>
+            </div>
         );
       default:
         return renderDashboard();
@@ -217,69 +241,70 @@ const MyPage = () => {
   };
 
   return (
-    <div className="mypage-container">
-      <div className="main-content">
-        {/* 왼쪽 메뉴 */}
-        <div className="sidebar">
-          <div className="menu-group">
-            <h3 className="menu-title">내 정보</h3>
-            <div className="menu-items">
-              <button onClick={openProfileEditSidebar}>프로필 수정</button>
-              <button onClick={openPasswordChangeSidebar}>비밀번호 변경</button>
-              <button onClick={openLocationSidebar}>거래지역 관리</button>
-              <button onClick={() => setActiveTab("child-management")}>자녀 관리</button>
-              <button
-                className="cursor-pointer"
-                onClick={(e) => {
-                  e.preventDefault();
-                  openWidthdrawalSidebar();
-                }}
-              >
-                탈퇴하기
-              </button>
+      <div className="mypage-container">
+        <div className="main-content">
+          {/* 왼쪽 메뉴 */}
+          <div className="sidebar">
+            <div className="menu-group">
+              <h3 className="menu-title">내 정보</h3>
+              <div className="menu-items">
+                <button onClick={openProfileEditSidebar}>프로필 수정</button>
+                <button onClick={openPasswordChangeSidebar}>비밀번호 변경</button>
+                <button onClick={openLocationSidebar}>거래지역 관리</button>
+                <button onClick={openChildManagementSidebar}>자녀 관리</button>
+                <button
+                    className="cursor-pointer"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      openWidthdrawalSidebar();
+                    }}
+                >
+                  탈퇴하기
+                </button>
+              </div>
+            </div>
+
+            <div className="menu-divider"></div>
+
+            <div className="menu-group">
+              <h3 className="menu-title">거래 정보</h3>
+              <div className="menu-items">
+                <a
+                    href="#"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      openWishlistSidebar();
+                    }}
+                >
+                  찜한 상품
+                </a>
+                <a
+                    href="#"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      setReviewOpen(true);
+                    }}
+                >
+                  리뷰 관리
+                </a>
+              </div>
             </div>
           </div>
 
-          <div className="menu-divider"></div>
-
-          <div className="menu-group">
-            <h3 className="menu-title">거래 정보</h3>
-            <div className="menu-items">
-              <a
-                href="#"
-                onClick={(e) => {
-                  e.preventDefault();
-                  openWishlistSidebar();
-                }}
-              >
-                찜한 상품
-              </a>
-              <a
-                href="#"
-                onClick={(e) => {
-                  e.preventDefault();
-                  setReviewOpen(true);
-                }}
-              >
-                리뷰 관리
-              </a>
-            </div>
-          </div>
+          {/* 오른쪽 컨텐츠 */}
+          <div className="content-area">{renderTabContent()}</div>
         </div>
 
-        {/* 오른쪽 컨텐츠 */}
-        <div className="content-area">{renderTabContent()}</div>
+        {/* 사이드바들 */}
+        <ProfileEdit />
+        <PasswordChange />
+        <MyReviewList open={reviewOpen} onClose={() => setReviewOpen(false)} />
+        <UserReviewList open={userReviewOpen} onClose={() => setUserReviewOpen(false)} />
+        <TradingAreaManagement />
+        <ChildManagement />
+        <WishlistSidebar trigger={<span style={{ display: "none" }}>숨김</span>} />
+        <WithdrawlSidebar />
       </div>
-
-      {/* 사이드바들 */}
-      <ProfileEdit />
-      <PasswordChange />
-      <MyReviewList open={reviewOpen} onClose={() => setReviewOpen(false)} />
-      <UserReviewList open={userReviewOpen} onClose={() => setUserReviewOpen(false)} />
-      <TradingAreaManagement />
-      <WishlistSidebar trigger={<span style={{ display: "none" }}>숨김</span>} />
-      <WithdrawlSidebar />
-    </div>
   );
 };
 


### PR DESCRIPTION
- 마이페이지에서 접근 가능한 자녀 관리 사이드바 추가
- 최대 2명까지 자녀 등록 가능 (애칭, 생년월일)
- 실시간 나이 계산 기능 (만 나이)
- HTML5 date picker를 통한 생년월일 선택
- 동적 폼 추가/삭제 기능 (+ 추가, ✕ 삭제)
- 모든 필수 입력 완료 시에만 저장 버튼 활성화
- 저장 완료 후 버튼 비활성화 처리
- 마이페이지 자녀 정보 섹션에 등록된 자녀 표시
- 더미데이터로 UI 플로우 완성
- 기존 코드 패턴 활용 (Sidebar, ConfirmModal, useSidebar)
- 안내 메시지 스타일 거래지역 관리와 통일