### PR TITLE
feat: 버튼 추가

### DIFF
--- a/src/app/product/[id]/page.jsx
+++ b/src/app/product/[id]/page.jsx
@@ -823,7 +823,7 @@ const ProductDetail = () => {
                             <div className='product-detail-trade-stat'>
                                 <span className='product-detail-stat-label'>리뷰수</span>
                                 {/* 리뷰 사이드바 */}
-                                <UserReviewList open={reviewSidebarOpen} onClose={() => setReviewSidebarOpen(false)} />
+                                <UserReviewList open={reviewSidebarOpen} onClose={() => setReviewSidebarOpen(false)} user={{ name: '닉넴닉크넴' }} />
                                 <a
                                     href='#'
                                     className='product-detail-stat-value'

--- a/src/app/review/components/MyReviewAddForm.jsx
+++ b/src/app/review/components/MyReviewAddForm.jsx
@@ -4,7 +4,7 @@ import React, { useState } from 'react';
 import ConfirmModal, { MODAL_TYPES } from '@/components/common/ConfirmModal';
 import '../css/MyReviewAddForm.css';
 
-const MyReviewAddForm = ({ onClose }) => {
+const MyReviewAddForm = ({ onClose ,nickname }) => {
     const [animateClass, setAnimateClass] = useState('animate-slide-in');
     const [rating, setRating] = useState(0);
     const [answers, setAnswers] = useState({
@@ -165,7 +165,7 @@ const MyReviewAddForm = ({ onClose }) => {
                                 <polyline points="15 18 9 12 15 6" />
                             </svg>
                         </button>
-                        <h1 className="sidebar-title">OO님과의 거래 리뷰 작성하기</h1>
+                        <h1 className="sidebar-title">{nickname || '사용자'} 님과의 거래 리뷰 작성하기</h1>
                     </div>
 
                     <div className="review-edit-content">
@@ -241,7 +241,7 @@ const MyReviewAddForm = ({ onClose }) => {
             {isLoading && (
                 <div className="custom-loading-modal">
                     <div className="modal-content">
-                        <div className="spinner"></div> {/* 스피너 */}
+                        <div className="spinner"></div>
                         <h2>등록 중</h2>
                         <p>리뷰를 등록하는 중입니다...</p>
                     </div>

--- a/src/app/review/components/MyReviewEditForm.jsx
+++ b/src/app/review/components/MyReviewEditForm.jsx
@@ -37,11 +37,11 @@ const MyReviewEditForm = ({ onClose, initialRating, initialAnswers, initialRevie
         // 일반적으로 리뷰에는 sellerId, buyerId, targetUserId 등의 필드가 있음
         // 현재 로그인한 유저와 다른 ID를 가진 유저가 상대방
 
-        if (review.sellerName && review.sellerName !== user?.name) {
+        if (review.sellerName && review.sellerName !== nickname?.name) {
             return review.sellerName;
         }
 
-        if (review.buyerName && review.buyerName !== user?.name) {
+        if (review.buyerName && review.buyerName !== nickname?.name) {
             return review.buyerName;
         }
 

--- a/src/app/review/components/MyReviewList.jsx
+++ b/src/app/review/components/MyReviewList.jsx
@@ -91,7 +91,7 @@ export default function MyReviewList({ open, onClose, user }) {
                     <h2 className="sidebar-title">나의 리뷰 내역</h2>
                 </div>
 
-                <div className="review-list">
+                <div className={`review-list ${reviews.length === 0 ? 'empty-state' : ''}`}>
                     {reviews.length > 0 ? (
                         reviews.map((review) => (
                             <div key={review.reviewId} className="review-item">
@@ -131,11 +131,19 @@ export default function MyReviewList({ open, onClose, user }) {
                                             );
                                         })}
                                     </div>
+                                    <div className="review-options">
+                                        {review.kind && <span className="review-badge kind-badge">친절해요</span>}
+                                        {!review.kind && <span className="review-badge unkind-badge">불친절해요</span>}
+                                        {review.promise && <span className="review-badge promise-badge">약속을 잘 지켜요</span>}
+                                        {!review.promise && <span className="review-badge unpromised-badge">약속을 안 지켜요</span>}
+                                        {review.satisfaction && <span className="review-badge satisfaction-badge">만족해요</span>}
+                                        {!review.satisfaction && <span className="review-badge unsatisfaction-badge">불만족스러워요</span>}
+                                    </div>
                                 </div>
                             </div>
                         ))
                     ) : (
-                        <p>작성된 리뷰가 없습니다.</p>
+                        <p>작성된 리뷰가 없습니다.</p> // 글자 폰트 크기 조절 및 가운데 정렬
                     )}
                 </div>
             </div>

--- a/src/app/review/components/UserReviewDetail.jsx
+++ b/src/app/review/components/UserReviewDetail.jsx
@@ -41,7 +41,7 @@ const UserReviewDetail = ({ review, onClose, user }) => {
                             <polyline points="15 18 9 12 15 6" />
                         </svg>
                     </button>
-                    <h1 className="sidebar-title">"{user?.name || '사용자'}"의 상세 리뷰 내역</h1>
+                    <h1 className="sidebar-title">"{user?.nickname || '구매자'}"의 상세 리뷰</h1>
                 </div>
 
                 <div className="review-detail-content">

--- a/src/app/review/components/UserReviewList.jsx
+++ b/src/app/review/components/UserReviewList.jsx
@@ -4,7 +4,7 @@ import React, { useState, useEffect } from 'react';
 import '../css/UserReviewList.css';
 import UserReviewDetail from './UserReviewDetail';
 
-const UserReviewList = ({ onClose, open, user }) => {
+const UserReviewList = ({ onClose, open, user,nickname }) => {
     const [isClosing, setIsClosing] = useState(false);
     const [activeFilter, setActiveFilter] = useState('all');
     const [showReviewDetail, setShowReviewDetail] = useState(false);
@@ -142,7 +142,7 @@ const UserReviewList = ({ onClose, open, user }) => {
                             <polyline points="15 18 9 12 15 6" />
                         </svg>
                     </button>
-                    <h2 className="review-title">"{user?.name || '사용자'}"님의 거래 리뷰 내역</h2>
+                    <h2 className="review-title">"{nickname || '사용자'}"님의 거래 리뷰 내역</h2>
                 </div>
 
                 <div className="average-rating-box">
@@ -160,7 +160,7 @@ const UserReviewList = ({ onClose, open, user }) => {
                             </p>
                         </div>
                     </div>
-                    <p>"{user?.name || '사용자'}"의 총 별점 평균과 총 리뷰 개수는</p>
+                    <p>"{nickname || '사용자'}"의 총 별점 평균과 총 리뷰 개수는</p>
                     <div className="big-stars">
                         {[1, 2, 3, 4, 5].map((starIndex) => (
                             <span key={starIndex} className="big-star-wrapper">
@@ -216,8 +216,9 @@ const UserReviewList = ({ onClose, open, user }) => {
                     </div>
                 </div>
 
-                <div className="review-list">
-                    {filteredReviews.map((review) => (
+                <div className={`review-list ${filteredReviews.length === 0 ? 'empty-state' : ''}`}>
+                    {filteredReviews.length > 0 ? (
+                    filteredReviews.map((review) => (
                         <div
                             className="review-card"
                             key={review.reviewId}
@@ -245,6 +246,16 @@ const UserReviewList = ({ onClose, open, user }) => {
                                         </span>
                                     ))}
                                 </div>
+                                <div className="review-options">
+                                    {/* 긍정 옵션 뱃지 */}
+                                    {review.kind && <span className="review-badge kind-badge">친절해요</span>}
+                                    {review.promise && <span className="review-badge promise-badge">약속을 잘 지켜요</span>}
+                                    {review.satisfaction && <span className="review-badge satisfaction-badge">만족해요</span>}
+                                    {/* 부정 옵션 뱃지 */}
+                                    {!review.kind && <span className="review-badge unkind-badge">불친절해요</span>}
+                                    {!review.promise && <span className="review-badge unpromised-badge">약속을 안 지켜요</span>}
+                                    {!review.satisfaction && <span className="review-badge unsatisfaction-badge">불만족스러워요</span>}
+                                </div>
                                 <div className="comment-text-box">
                                     <p className="review-comment">{review.summary}</p>
                                 </div>
@@ -256,7 +267,9 @@ const UserReviewList = ({ onClose, open, user }) => {
                                 리뷰 상세
                             </button>
                         </div>
-                    ))}
+                    ))   ) : (
+                        <p>작성된 리뷰가 없습니다.</p>
+                    )}
                 </div>
             </aside>
             {selectedReview && (

--- a/src/app/review/css/MyReviewList.css
+++ b/src/app/review/css/MyReviewList.css
@@ -196,18 +196,64 @@ body {
     color: #000000;
     text-align: center;
 }
+.review-options {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+    margin-top: 2px;
+}
 
+.review-badge {
+    padding: 3px 8px;
+    border-radius: 12px;
+    font-size: 0.75rem;
+    font-weight: 500;
+}
+
+/* 긍정 옵션 뱃지 색상 */
+.kind-badge {
+    background-color: #e0f7fa;
+    color: #00796b;
+}
+
+.promise-badge {
+    background-color: #fce4ec;
+    color: #ad1457;
+}
+
+.satisfaction-badge {
+    background-color: #f1f8e9;
+    color: #33691e;
+}
+
+/* 부정 옵션 뱃지 색상 */
+.unkind-badge, .unpromised-badge, .unsatisfaction-badge {
+    background-color: #ffebee;
+    color: #c62828;
+}
 /* Review List */
 .review-list {
     padding: 20px;
 }
+/* empty-state 클래스가 있을 때만 내용을 중앙 정렬합니다. */
+.review-list.empty-state {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 150px;
+}
 
+/* 리뷰가 없을 때 표시되는 <p> 태그의 스타일 */
+.review-list.empty-state p {
+    font-size: 1.2rem;
+    color: #999;
+}
 .review-item {
     display: flex;
     gap: 20px;
     padding: 20px 0;
     border-bottom: 1px solid #DDDDDD;
-    cursor: pointer; /* Added cursor pointer for clickability */
+    cursor: pointer;
 }
 
 .review-item:hover {

--- a/src/app/review/css/UserReviewList.css
+++ b/src/app/review/css/UserReviewList.css
@@ -241,7 +241,41 @@
 .filter-button:not(.active):hover {
     background-color: #e0e0e0;
 }
+.review-options {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+    margin-top: 5px;
+}
 
+.review-badge {
+    padding: 3px 8px;
+    border-radius: 12px;
+    font-size: 0.75rem;
+    font-weight: 500;
+}
+
+/* 긍정 옵션 뱃지 색상 */
+.kind-badge {
+    background-color: #e0f7fa; /* 연한 파란색 배경 */
+    color: #00796b; /* 글자색 */
+}
+
+.promise-badge {
+    background-color: #fce4ec;
+    color: #ad1457;
+}
+
+.satisfaction-badge {
+    background-color: #f1f8e9;
+    color: #33691e;
+}
+
+/* 부정 옵션 뱃지 색상 */
+.unkind-badge, .unpromised-badge, .unsatisfaction-badge {
+    background-color: #ffebee; /* 연한 빨간색 배경 */
+    color: #c62828; /* 글자색 */
+}
 /* 리뷰 리스트 */
 .review-list {
     padding: 10px 20px;
@@ -249,7 +283,18 @@
     flex-direction: column;
     gap: 16px;
 }
-
+/* empty-state 클래스가 있을 때만 Flexbox를 적용하여 내용을 중앙 정렬합니다. */
+.review-list.empty-state {
+    display: flex;
+    justify-content: center; /* 수평 중앙 정렬 */
+    align-items: center;     /* 수직 중앙 정렬 */
+    min-height: 150px;       /* 최소 높이를 설정하여 중앙 정렬 공간 확보 */
+}
+/* 리뷰가 없을 때 표시되는 <p> 태그의 스타일 */
+.review-list.empty-state p {
+    font-size: 1.2rem; /* 글자 크기를 키웁니다. */
+    color: #999;
+}
 /* 개별 리뷰 카드 */
 .review-card {
     display: flex;


### PR DESCRIPTION
feat: 상대 리뷰 리스트와 나의 리뷰 리스트에 본인 또는 리뷰 작성 유저가 선택한 옵션 버튼을 표시하는 기능 추가

docs: 상대방, 구매자로 나누어 nickname 이 있으면 nickname 표시 없다면 구매자, 판매자, 사용자로 표시
 - 상대 유저 리스트에서는 사용자로 표시 (사용자의 리뷰 내역 , 사용자의 별점 평균과 리뷰 개수)
 - 상대 리뷰 상세 보기에서는 구매자로 표시 (리뷰를 작성한 사람 nickname)
 - 나의 구매 리스트에서의 수정하기 사이드 바 진입 시 상대방으로 표시 (판매자 즉 상대 거래자의 nickname)