### PR TITLE
feat: 마이페이지에 상품 서비스 API 연동

### DIFF
--- a/src/store/mypageStore.js
+++ b/src/store/mypageStore.js
@@ -1,7 +1,7 @@
 // store/myPageStore.js
 
 import { create } from 'zustand';
-import { userAPI } from '@/lib/api';
+import { userAPI, productAPI } from '@/lib/api';
 
 export const useMyPageStore = create((set) => ({
     // 대시보드 섹션
@@ -9,28 +9,24 @@ export const useMyPageStore = create((set) => ({
         profileInfo: null,
         childrenList: [],
         tradingSummary: null,
+        purchasedProducts: [], // 구매 상품 목록
+        soldProducts: [],      // 판매 상품 목록
     },
 
     // 로딩 상태
-    loading: { dashboard: false },
+    loading: {
+        dashboard: false,
+        purchases: false, // 구매 상품 로딩 상태
+        sales: false,     // 판매 상품 로딩 상태
+    },
     error: null,
 
     // 통합 대시보드 정보를 한 번에 가져오는 함수
     getMypageDashboard: async (userId) => {
         set(state => ({ loading: { ...state.loading, dashboard: true }, error: null }));
         try {
-            if (!userId) {
-                console.error('사용자 ID가 없습니다.');
-                set(state => ({
-                    error: '사용자 ID가 없습니다.',
-                    loading: { ...state.loading, dashboard: false },
-                }));
-                return;
-            }
-
             // userAPI 사용 (이미 api.js에 정의되어 있음)
             const response = await userAPI.getMypageDashboard();
-            console.log('백엔드 응답 원본:', response.data);
 
             if (response.data.success) {
                 const { profileInfo, childList, transactionSummary } = response.data.data;
@@ -57,12 +53,76 @@ export const useMyPageStore = create((set) => ({
             }));
         }
     },
+
+    // 구매 상품 목록을 가져오는 함수
+    getPurchasedProducts: async () => {
+        set(state => ({ loading: { ...state.loading, purchases: true }, error: null }));
+        try {
+            const response = await productAPI.getMyPurchases();
+            if (response.data.success) {
+                set(state => ({
+                    dashboard: {
+                        ...state.dashboard,
+                        purchasedProducts: response.data.data,
+                    },
+                    loading: { ...state.loading, purchases: false },
+                }));
+            } else {
+                set(state => ({
+                    error: response.data.message,
+                    loading: { ...state.loading, purchases: false },
+                }));
+            }
+        } catch (error) {
+            console.error('구매 상품 목록 조회 실패:', error.response?.data?.message || error.message);
+            set(state => ({
+                error: error.response?.data?.message || '구매 상품 목록 조회 실패',
+                loading: { ...state.loading, purchases: false },
+            }));
+        }
+    },
+
+    // 판매 상품 목록을 가져오는 함수
+    getSoldProducts: async () => {
+        set(state => ({ loading: { ...state.loading, sales: true }, error: null }));
+        try {
+            const response = await productAPI.getMySales();
+            if (response.data.success) {
+                set(state => ({
+                    dashboard: {
+                        ...state.dashboard,
+                        soldProducts: response.data.data,
+                    },
+                    loading: { ...state.loading, sales: false },
+                }));
+            } else {
+                set(state => ({
+                    error: response.data.message,
+                    loading: { ...state.loading, sales: false },
+                }));
+            }
+        } catch (error) {
+            console.error('판매 상품 목록 조회 실패:', error.response?.data?.message || error.message);
+            set(state => ({
+                error: error.response?.data?.message || '판매 상품 목록 조회 실패',
+                loading: { ...state.loading, sales: false },
+            }));
+        }
+    },
 }));
 
-// 선택자들
+// 모든 데이터 선택자들
 export const useProfileInfo = () => useMyPageStore(state => state.dashboard.profileInfo);
 export const useChildrenList = () => useMyPageStore(state => state.dashboard.childrenList);
 export const useTradingSummary = () => useMyPageStore(state => state.dashboard.tradingSummary);
+export const usePurchasedProducts = () => useMyPageStore(state => state.dashboard.purchasedProducts);
+export const useSoldProducts = () => useMyPageStore(state => state.dashboard.soldProducts);
+
+// 로딩/에러 선택자들
 export const useMyPageLoading = () => useMyPageStore(state => state.loading);
 export const useMyPageError = () => useMyPageStore(state => state.error);
+
+// 액션 선택자들 마지막
 export const useGetMypageDashboard = () => useMyPageStore(state => state.getMypageDashboard);
+export const useGetPurchasedProducts = () => useMyPageStore(state => state.getPurchasedProducts);
+export const useGetSoldProducts = () => useMyPageStore(state => state.getSoldProducts);


### PR DESCRIPTION
작업 내용
- 구매/판매 상품 탭에 실제 API 데이터 연동

마이페이지 내 구매 상품 및 판매 상품 탭에 백엔드 API (/me/purchases, /me/sales)를 연결하여 실제 데이터를 불러오도록 구현

- 탭별 데이터 로딩 상태 및 지연 로딩 추가

zustand 스토어에 loading.purchases와 loading.sales 상태를 추가하여, 각 탭의 데이터 로딩 상태를 관리

탭 전환 시 필요한 데이터만 비동기로 가져와 UX를 개선

- 빈 상품 목록에 대한 UI 처리

구매 또는 판매 상품 목록이 비어있을 경우, "등록된 상품이 없습니다."라는 메시지를 표시하도록 예외 처리 UI를 구현

- 발견된 이슈
구매 상품 탭에 상품 목록이 노출되지 않는 이슈가 발견

프론트엔드: API 요청은 정상적이며, 응답으로 빈 배열([])을 받고 있음

백엔드: 백엔드 로그 확인 결과, 구매 상품 조회 쿼리가 buyer_id is null을 사용하고 있어, 올바른 사용자 ID로 조회되지 않는 것으로 보임. 백엔드 수정이 필요

이번 커밋은 마이페이지의 핵심 기능을 구현한 내용.
백엔드 이슈가 해결되면 정상적으로 상품이 표시될 것