### PR TITLE
Feat: 프로필 수정 기능 로직 개선 및 오류 해결

### DIFF
--- a/src/app/(user)/mypage/page.jsx
+++ b/src/app/(user)/mypage/page.jsx
@@ -291,16 +291,34 @@ const MyPage = () => {
     // 프로필 수정
     const handleProfileUpdate = async (updatedData) => {
         try {
+            const changes = {};
 
-            // 전화번호에서 하이픈(-)을 제거
+            // 닉네임 변경 여부 확인
+            if (updatedData.nickname !== (profileInfo?.nickname || '')) {
+                changes.nickname = updatedData.nickname;
+            }
+
+            // 이메일 변경 여부 확인
+            if (updatedData.email !== (profileInfo?.email || '')) {
+                changes.email = updatedData.email;
+            }
+
+            // 전화번호 변경 여부 확인 및 하이픈 제거
             const cleanedPhoneNumber = extractPhoneNumbers(updatedData.phone);
+            if (cleanedPhoneNumber !== (profileInfo?.phoneNumber || '')) {
+                changes.phoneNumber = cleanedPhoneNumber;
+            }
 
-            // 백엔드 API 호출
-            const response = await userAPI.updateProfile({
-                nickname: updatedData.nickname,
-                email: updatedData.email,
-                phoneNumber: cleanedPhoneNumber
-            });
+            // 변경된 사항이 없으면 API 호출하지 않고 종료
+            if (Object.keys(changes).length === 0) {
+                console.log('변경된 사항이 없어 프로필 업데이트를 건너뜁니다.');
+                return { success: true };
+            }
+
+            console.log('최종 전송 데이터:', changes);
+
+            // 백엔드 API 호출 - 변경된 데이터만 전송
+            const response = await userAPI.updateProfile(changes);
 
             console.log('프로필 수정 성공:', response.data);
 

--- a/src/app/(user)/profile-edit/page.jsx
+++ b/src/app/(user)/profile-edit/page.jsx
@@ -52,18 +52,20 @@ const ProfileEdit = ({ currentUserInfo, onProfileUpdate }) => {
 
     // 컴포넌트 마운트 시 현재 사용자 정보로 초기화
     useEffect(() => {
+        // currentUserInfo가 존재하면 폼 데이터를 업데이트
         if (currentUserInfo) {
             setFormData({
                 nickname: currentUserInfo.nickname || '',
                 email: currentUserInfo.email || '',
-                phone: currentUserInfo.phoneNumber || currentUserInfo.phone || ''
+                phone: currentUserInfo.phoneNumber || ''
             });
         }
-    }, [currentUserInfo]);
+    }, [currentUserInfo]); // currentUserInfo가 바뀔 때마다 실행
 
     // 변경사항 감지
     useEffect(() => {
         if (currentUserInfo) {
+            // formData가 업데이트된 후 변경사항을 감지
             const isChanged =
                 formData.nickname !== (currentUserInfo.nickname || '') ||
                 formData.email !== (currentUserInfo.email || '') ||
@@ -153,11 +155,28 @@ const ProfileEdit = ({ currentUserInfo, onProfileUpdate }) => {
         setIsCompleteModalOpen(false);
     };
 
+    // 변경사항이 있는지 확인하는 헬퍼 함수
+    const hasFieldChanged = (field) => {
+        // 백엔드 키와 프론트엔드 키를 매핑
+        const userInfoKey = {
+            'nickname': 'nickname',
+            'email': 'email',
+            'phone': 'phoneNumber',
+        };
+
+        const key = userInfoKey[field];
+
+        if (!currentUserInfo) return false;
+
+        // 기존 값과 현재 폼 데이터 값을 비교
+        return formData[field] !== (currentUserInfo[key] || '');
+    };
+
     // 저장 버튼 활성화 조건
-    const isSaveEnabled = hasChanges && currentUserInfo &&
-        (validationStates.nickname.checked || formData.nickname === (currentUserInfo.nickname || '')) &&
-        (validationStates.email.checked || formData.email === (currentUserInfo.email || '')) &&
-        (validationStates.phone.status === 'success' || validationStates.phone.status === 'default');
+    const isSaveEnabled = hasChanges &&
+        (!hasFieldChanged('nickname') || validationStates.nickname.checked) &&
+        (!hasFieldChanged('email') || validationStates.email.checked) &&
+        (!hasFieldChanged('phone') || validationStates.phone.status === 'success');
 
     return (
         <>


### PR DESCRIPTION
- 기존: 프로필 수정 시, 모든 필드(닉네임, 이메일, 전화번호)를 전송하여 변경되지 않은 필드에 대한 유효성 검사 오류(400 Bad Request)가 발생
- 개선: 변경된 필드만 식별하여 해당 데이터만 백엔드에 전송하도록 수정. 이로써 불필요한 데이터 전송을 줄이고 API 유효성 검사 오류를 방지
- MyPage 컴포넌트의 handleProfileUpdate 함수 로직을 수정하여 profileInfo와 updatedData를 비교하는 변경사항 감지 로직 추가
- ProfileEdit 컴포넌트의 상태 초기화 로직을 개선하여 사용자 정보가 로드될 때 폼이 올바르게 초기화되도록 수정