### PR TITLE
fix: API timeout 증가 및 마이페이지 총 판매 수 표시 수정

### DIFF
--- a/src/app/(user)/mypage/page.jsx
+++ b/src/app/(user)/mypage/page.jsx
@@ -209,7 +209,7 @@ const MyPage = () => {
                         </div>
                         <div className="transaction-item">
                             <span className="transaction-label">총 판매</span>
-                            <span className="transaction-value">{tradingSummary?.saleCount || 0}</span>
+                            <span className="transaction-value">{tradingSummary?.totalSalesCount || 0}</span>
                             <span className="transaction-unit">건</span>
                         </div>
                         <div className="transaction-item">

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -15,7 +15,7 @@ const POST_URL = "/post-service";
 // axios 기본 설정 (쿠키 기반 인증)
 const api = axios.create({
   baseURL: API_BASE_URL,
-  timeout: 15000, // 15초로 변경
+  timeout: 30000, // 30초로 변경
   headers: {
     "Content-Type": "application/json",
   },


### PR DESCRIPTION
## 수정 사항
- API 타임아웃을 15초에서 30초로 증가하여 판매 상품 조회 시 타임아웃 에러 해결
- 마이페이지 거래 현황에서 총 판매 수가 0으로 표시되던 문제 수정 (saleCount → totalSalesCount)

## 변경 파일
- `lib/api.js`: axios timeout 설정 변경
- `app/(user)/mypage/page.js`: 총 판매 수 필드명 수정